### PR TITLE
safeguard: add propose_guard tool for agent-initiated trust directives

### DIFF
--- a/.changeset/safeguard-propose-guard.md
+++ b/.changeset/safeguard-propose-guard.md
@@ -1,0 +1,5 @@
+---
+"pi-safeguard": minor
+---
+
+Add `propose_trust` tool that lets the agent request permission when blocked by the security guardrail. The user sees the proposed trust rule with the agent's reasoning and can accept or reject with one keypress. Accepted rules work like `/guard` — they persist for the session.

--- a/packages/safeguard/README.md
+++ b/packages/safeguard/README.md
@@ -64,6 +64,21 @@ When the judge gets it wrong for your situation, use `/guard`:
 
 Directives persist for the session and are included in every judge evaluation. `/guard` with no argument shows active directives, `/guard reset` clears them.
 
+### Agent-proposed trust rules
+
+When the agent gets blocked, it can use the `propose_trust` tool to request permission instead of asking you to type `/guard` manually. You'll see the proposed rule with the agent's reasoning and can accept or reject with one keypress:
+
+```
+🛡️ Trust rule proposed
+
+📋 Allow edits to safeguard source code in packages/safeguard/
+💬 User asked me to implement config redesign for pi-safeguard
+
+> Accept / Reject
+```
+
+Accepted rules work exactly like `/guard` — they persist for the session and are included in judge evaluations.
+
 ## Custom rules
 
 Add your own commands and patterns to flag. Useful for tools specific to your workflow (deploy scripts, cloud CLIs, etc.).

--- a/packages/safeguard/src/config.ts
+++ b/packages/safeguard/src/config.ts
@@ -147,7 +147,7 @@ export const USER_MSG_TAIL = 100;
 export const BASH_DETAIL_LEN = 50;
 
 export const DEFAULT_DENY_GUIDANCE =
-	"This action was blocked by the security guardrail. Consider a different approach, ask the user to run the command directly, or ask the user to grant access with /guard.";
+	"This action was blocked by the security guardrail. Consider a different approach, ask the user to run the command directly, or use the propose_trust tool to request permission for this session.";
 
 const BASE_SYSTEM_PROMPT = `You are a security guardrail for an AI coding agent. You evaluate actions that were flagged by automatic pattern matching.
 

--- a/packages/safeguard/src/index.ts
+++ b/packages/safeguard/src/index.ts
@@ -18,11 +18,12 @@
  * suggesting alternative approaches. Previous verdicts are stored in the
  * session and included in context so the judge can detect circumvention.
  *
- * Use /guard to add per-session trust directives.
+ * Use /guard to add per-session trust directives, or the agent can propose
+ * directives via the propose_guard tool.
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
 import { type BudgetModel, findBudgetModel } from "pi-budget-model";
 import {
 	DEFAULT_DENY_GUIDANCE,
@@ -47,6 +48,8 @@ export default function (pi: ExtensionAPI) {
 
 	const systemPrompt = buildSystemPrompt(config);
 
+	// --- /guard command ---
+
 	pi.registerCommand("guard", {
 		description: "Manage safeguard: /guard <trust directive> or /guard reset",
 		handler: async (args, ctx) => {
@@ -69,6 +72,80 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.notify(`🛡️ Trust directive added: ${trimmed}`);
 		},
 	});
+
+	// --- propose_trust tool ---
+
+	pi.registerTool({
+		name: "propose_trust",
+		label: "Propose Trust Rule",
+		description:
+			"Request permission for something the security guardrail blocked. Proposes a trust rule for the user to accept or reject. Accepted rules instruct the security judge for the remainder of the session, so propose broad rules covering your task rather than one-off approvals.",
+		promptSnippet:
+			"Request permission for something the security guardrail blocked (proposes a session-wide trust rule for the user to approve)",
+		promptGuidelines: [
+			"When blocked by the security guardrail, use propose_trust to request permission instead of asking the user to type /guard manually.",
+			"Accepted rules last for the entire session, so propose rules that cover the task broadly rather than one-off approvals.",
+			"Keep rules brief but explicit about what is allowed. Good: 'Allow .env file access', 'Allow terraform plan and apply'. Bad: 'Allow dangerous commands', 'Allow everything needed for this task'.",
+			"The reason field is optional. Only include it if the rule isn't self-explanatory. Don't repeat information from the rule.",
+		],
+		parameters: Type.Object({
+			rule: Type.String({
+				description:
+					"Brief, explicit trust rule stating what is allowed (e.g. 'Allow .env file access', 'Allow terraform commands', 'Allow editing safeguard source')",
+			}),
+			reason: Type.Optional(
+				Type.String({
+					description: "Only if the rule isn't self-explanatory. Don't repeat the rule.",
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (!ctx) {
+				return {
+					content: [{ type: "text", text: "Rejected: no UI context available." }],
+					details: {},
+				};
+			}
+
+			if (!ctx.hasUI) {
+				return {
+					content: [{ type: "text", text: "Rejected: no interactive UI available." }],
+					details: {},
+				};
+			}
+
+			const lines = ["🛡️ Trust rule proposed", `\n📋 ${params.rule}`];
+			if (params.reason) lines.push(`\n💬 ${params.reason}`);
+			lines.push("");
+
+			const choice = await ctx.ui.select(lines.join("\n"), ["Accept", "Reject"]);
+
+			if (choice === "Accept") {
+				pi.appendEntry(TRUST_ENTRY_TYPE, params.rule);
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Trust rule accepted for this session: "${params.rule}". You can now retry the blocked action.`,
+						},
+					],
+					details: {},
+				};
+			}
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Trust rule rejected by user. Try a different approach, or ask the user to run the command directly.",
+					},
+				],
+				details: {},
+			};
+		},
+	});
+
+	// --- Tool call interception ---
 
 	/** Whether the next tool call needs a post-denial circumvention check. */
 	let needsPostDenialCheck = false;
@@ -176,7 +253,7 @@ async function askUser(
 		return { block: true, reason: DEFAULT_DENY_GUIDANCE };
 	}
 
-	const lines = ["⚠️ Needs approval", `\n🤖 ${explanation}`, `\n  ${action}\n`];
+	const lines = ["Command needs approval. Agent's explanation:", `> ${explanation}`, `\n${action}`];
 	const choice = await ctx.ui.select(lines.join("\n"), ["Allow", "Deny", "Stop"]);
 
 	if (choice === "Allow") {

--- a/packages/safeguard/tsup.config.ts
+++ b/packages/safeguard/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
 	format: "esm",
 	dts: true,
 	clean: true,
-	external: ["@mariozechner/pi-ai", "@mariozechner/pi-coding-agent", "pi-budget-model"],
+	external: ["@mariozechner/pi-ai", "@mariozechner/pi-coding-agent", "@sinclair/typebox", "pi-budget-model"],
 });


### PR DESCRIPTION
## Summary

When the agent gets blocked by safeguard, it can now use the `propose_guard` tool to request a trust directive instead of telling the user to type `/guard` manually. The user sees the proposed directive with the agent's reasoning and can accept or reject with one keypress.

### How it works

1. Agent gets blocked (e.g. trying to edit safeguard source code)
2. Agent calls `propose_guard` with a directive and reason
3. User sees:
   ```
   🛡️ Guard directive proposed
   
   📋 Allow edits to safeguard source code in packages/safeguard/
   💬 User asked me to implement config redesign for pi-safeguard
   
   > Accept / Reject
   ```
4. If accepted, directive persists for the session (same as `/guard`)

### Design choices

- Directives are **session-wide** — the tool's prompt guidelines nudge the LLM to propose broad, task-level directives rather than one-off approvals
- Uses `ctx.ui.select` for the accept/reject dialog — consistent with existing safeguard UI
- `DEFAULT_DENY_GUIDANCE` updated to mention `propose_guard` so the agent knows it's available
- `@sinclair/typebox` added to tsup externals (used for tool parameter schema, provided by pi at runtime)

### Changes

- `src/index.ts`: Register `propose_guard` tool with `promptSnippet` and `promptGuidelines`
- `src/config.ts`: Update deny guidance to reference `propose_guard`
- `tsup.config.ts`: Add `@sinclair/typebox` to externals
- `README.md`: Document agent-proposed directives
