### PR TITLE
feat: add pi-after-hours extension package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Monorepo of extensions and libraries for [pi](https://pi.dev). Managed with Yarn
 | pi-bash-trim | `packages/bash-trim/` | pi extension |
 | pi-desktop-notify | `packages/desktop-notify/` | pi extension + library |
 | pi-budget-model | `packages/budget-model/` | library |
+| pi-after-hours | `packages/after-hours/` | pi extension |
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities for running [pi](https://pi.dev) agents with less babysitting: auto-re
 Install the extensions together, or pick only the ones you want. Defaults are tuned for good behavior out of the box.
 
 ```bash
-pi install pi-safeguard pi-bash-trim pi-desktop-notify
+pi install pi-safeguard pi-bash-trim pi-desktop-notify pi-after-hours
 ```
 
 ### [pi-safeguard](packages/safeguard/)
@@ -25,6 +25,10 @@ Smart bash output trimming. Intercepts tool results before they enter the contex
 ### [pi-desktop-notify](packages/desktop-notify/)
 
 Desktop notifications with terminal focus tracking. Notifications are suppressed while the terminal is in the foreground and only fire when you've tabbed away — so you hear about finished tasks without being interrupted mid-thought. Click-to-focus brings the terminal back. Works on macOS (terminal-notifier) and Linux (notify-send), with compositor support for niri, sway, and hyprland.
+
+### [pi-after-hours](packages/after-hours/)
+
+Message budget for quiet hours. During configurable quiet hours (default 23:00–07:00), you get a limited number of messages (default 3). After the budget is spent, pi's UI is replaced with a full-screen block until quiet hours end — the agent keeps working on your last request, you check results in the morning. Counter resets daily and doesn't survive reboots; the goal is breaking the autopilot loop, not hard enforcement.
 
 ## Libraries
 

--- a/packages/after-hours/README.md
+++ b/packages/after-hours/README.md
@@ -6,6 +6,8 @@ Break the late-night engagement loop.
 
 During quiet hours (default 23:00–07:00), you get a configurable number of messages (default 3). After the budget is spent, pi's UI is replaced with a full-screen block until quiet hours end. The agent continues processing your last message normally — check results in the morning.
 
+When auto-sleep is enabled (default), the block screen tracks the agent's progress. Once the agent finishes, a countdown begins and the computer is put to sleep automatically. Press any key to cancel the countdown.
+
 ## Install
 
 ```bash
@@ -23,7 +25,9 @@ Place `pi-after-hours.json` in `~/.pi/agent/extensions/`:
   "quietHoursEnd": "07:00",
   "messageLimit": 3,
   "warningTime": "23:30",
-  "blockMessage": "The agent is working. You can rest now and check results in the morning."
+  "blockMessage": "The agent is working. You can rest now and check results in the morning.",
+  "autoSleep": true,
+  "autoSleepDelay": 30
 }
 ```
 
@@ -37,6 +41,8 @@ All fields are optional — defaults are shown above.
 | `messageLimit` | number (≥0) | Messages allowed during quiet hours (0 = block immediately) |
 | `warningTime` | `"HH:MM"` | When to show the countdown widget |
 | `blockMessage` | string | Text shown on the block screen |
+| `autoSleep` | boolean | Suspend the computer after the agent finishes (default: true) |
+| `autoSleepDelay` | number (5–300) | Seconds to wait before suspending (default: 30) |
 
 Quiet hours crossing midnight (e.g. 23:00–07:00) are handled correctly.
 
@@ -49,10 +55,20 @@ Quiet hours crossing midnight (e.g. 23:00–07:00) are handled correctly.
 **After warning time (or first message sent):** Widget shows above the editor:
 > 🌙 Quiet hours active. 3 messages remaining tonight.
 
-**After final message:** Full-screen block with centered box. Ctrl+C/Ctrl+D to exit pi. The block auto-dismisses when quiet hours end.
+**After final message:** Full-screen block with centered box.
+
+**While agent is working:** Block screen shows "🔄 Agent is still working…"
+
+**When agent finishes:** Countdown begins: "💤 Computer will sleep in 30s" — ticks down every second, then suspends the system (`systemctl suspend` on Linux, `pmset sleepnow` on macOS).
+
+**Cancel auto-sleep:** Press any key (except Ctrl+C/Ctrl+D) to cancel the countdown. The block screen stays but shows "Auto-sleep disabled".
+
+**Exit pi:** Ctrl+C or Ctrl+D exits pi at any time from the block screen.
+
+**Quiet hours end:** The block auto-dismisses when quiet hours end.
 
 **Counter persistence:** Message count is stored in `/tmp/pi-after-hours-{date}.json` and resets daily. A reboot also resets it.
 
 ## Commands
 
-- `/after-hours` — Show current status (quiet hours active, budget remaining)
+- `/after-hours` — Show current status (quiet hours active, budget remaining, auto-sleep config)

--- a/packages/after-hours/README.md
+++ b/packages/after-hours/README.md
@@ -1,0 +1,58 @@
+# pi-after-hours
+
+> From [yapp](https://github.com/mgabor3141/yapp) · yet another pi pack
+
+Break the late-night engagement loop.
+
+During quiet hours (default 23:00–07:00), you get a configurable number of messages (default 3). After the budget is spent, pi's UI is replaced with a full-screen block until quiet hours end. The agent continues processing your last message normally — check results in the morning.
+
+## Install
+
+```bash
+pi install npm:pi-after-hours
+```
+
+## Configuration
+
+Place `pi-after-hours.json` in `~/.pi/agent/extensions/`:
+
+```json
+{
+  "enabled": true,
+  "quietHoursStart": "23:00",
+  "quietHoursEnd": "07:00",
+  "messageLimit": 3,
+  "warningTime": "23:30",
+  "blockMessage": "The agent is working. You can rest now and check results in the morning."
+}
+```
+
+All fields are optional — defaults are shown above.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enable/disable the extension |
+| `quietHoursStart` | `"HH:MM"` | When quiet hours begin (local time) |
+| `quietHoursEnd` | `"HH:MM"` | When quiet hours end (local time) |
+| `messageLimit` | number (≥0) | Messages allowed during quiet hours (0 = block immediately) |
+| `warningTime` | `"HH:MM"` | When to show the countdown widget |
+| `blockMessage` | string | Text shown on the block screen |
+
+Quiet hours crossing midnight (e.g. 23:00–07:00) are handled correctly.
+
+## Behavior
+
+**Before quiet hours:** Normal operation, no restrictions.
+
+**During quiet hours, before warning time:** Normal operation, no UI changes.
+
+**After warning time (or first message sent):** Widget shows above the editor:
+> 🌙 Quiet hours active. 3 messages remaining tonight.
+
+**After final message:** Full-screen block with centered box. Ctrl+C/Ctrl+D to exit pi. The block auto-dismisses when quiet hours end.
+
+**Counter persistence:** Message count is stored in `/tmp/pi-after-hours-{date}.json` and resets daily. A reboot also resets it.
+
+## Commands
+
+- `/after-hours` — Show current status (quiet hours active, budget remaining)

--- a/packages/after-hours/dev/default.json
+++ b/packages/after-hours/dev/default.json
@@ -1,0 +1,6 @@
+{
+  "quietHoursStart": "23:00",
+  "quietHoursEnd": "07:00",
+  "messageLimit": 3,
+  "warningTime": "23:30"
+}

--- a/packages/after-hours/dev/immediate.json
+++ b/packages/after-hours/dev/immediate.json
@@ -1,0 +1,7 @@
+{
+  "quietHoursStart": "00:00",
+  "quietHoursEnd": "23:59",
+  "messageLimit": 0,
+  "warningTime": "00:00",
+  "autoSleep": false
+}

--- a/packages/after-hours/dev/quick.json
+++ b/packages/after-hours/dev/quick.json
@@ -1,0 +1,7 @@
+{
+  "quietHoursStart": "00:00",
+  "quietHoursEnd": "23:59",
+  "messageLimit": 2,
+  "warningTime": "00:00",
+  "autoSleep": false
+}

--- a/packages/after-hours/dev/sleep.json
+++ b/packages/after-hours/dev/sleep.json
@@ -1,0 +1,8 @@
+{
+  "quietHoursStart": "00:00",
+  "quietHoursEnd": "23:59",
+  "messageLimit": 2,
+  "warningTime": "00:00",
+  "autoSleep": true,
+  "autoSleepDelay": 10
+}

--- a/packages/after-hours/dev/test.sh
+++ b/packages/after-hours/dev/test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap 'echo "Error on line $LINENO: $BASH_COMMAND" >&2' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(dirname "$SCRIPT_DIR")"
+
+# --- Usage ---
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [preset] [-- pi-args...]
+
+Builds the extension and launches pi with a test config preset.
+Everything after -- is passed through to pi.
+
+Presets (from dev/):
+  quick       Always quiet hours, 2 messages, no auto-sleep (default)
+  immediate   Always quiet hours, 0 messages (instant block)
+  sleep       Always quiet hours, 2 messages, 10s auto-sleep countdown
+  default     Production defaults (only active 23:00–07:00)
+
+Examples:
+  ./dev/test.sh                     # quick preset
+  ./dev/test.sh sleep               # test auto-sleep countdown
+  ./dev/test.sh immediate           # instant block screen
+  ./dev/test.sh -- -p "hello"       # quick preset, print mode
+EOF
+  exit 0
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+# --- Parse args ---
+PRESET="${1:-quick}"
+shift || true
+
+# Consume -- separator if present
+[[ "${1:-}" == "--" ]] && shift
+
+CONFIG="$SCRIPT_DIR/$PRESET.json"
+if [[ ! -f "$CONFIG" ]]; then
+  echo "Unknown preset: $PRESET" >&2
+  echo "Available: $(ls "$SCRIPT_DIR"/*.json | xargs -I{} basename {} .json | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# --- Build ---
+echo "Building..."
+(cd "$PKG_DIR" && yarn build 2>&1 | grep -E '(error|Build success)' || true)
+
+# --- Launch ---
+echo "Preset: $PRESET ($CONFIG)"
+echo "---"
+exec env PI_AFTER_HOURS_CONFIG="$CONFIG" \
+  pi -ne -e "$PKG_DIR/dist/index.js" --no-skills --no-prompt-templates --no-session "$@"

--- a/packages/after-hours/package.json
+++ b/packages/after-hours/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "pi-after-hours",
+  "version": "0.1.0",
+  "description": "Message budget for quiet hours — break the late-night engagement loop",
+  "author": "mgabor3141",
+  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/mgabor3141/yapp.git",
+    "directory": "packages/after-hours"
+  },
+  "keywords": [
+    "pi-package",
+    "wellbeing",
+    "quiet-hours",
+    "message-limit"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "dependencies": {
+    "valibot": "^1.2.0"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-tui": "^0.57.0",
+    "@types/node": "^25.3.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/after-hours/package.json
+++ b/packages/after-hours/package.json
@@ -28,7 +28,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "./dev/test.sh",
+    "dev:sleep": "./dev/test.sh sleep",
+    "dev:immediate": "./dev/test.sh immediate"
   },
   "pi": {
     "extensions": [

--- a/packages/after-hours/src/config.ts
+++ b/packages/after-hours/src/config.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as v from "valibot";
+
+// --- Schema ---
+
+const TimeString = v.pipe(
+	v.string(),
+	v.regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, 'Must be a valid "HH:MM" time (00:00–23:59)'),
+);
+
+export const AfterHoursConfig = v.object({
+	enabled: v.optional(v.boolean(), true),
+	quietHoursStart: v.optional(TimeString, "23:00"),
+	quietHoursEnd: v.optional(TimeString, "07:00"),
+	messageLimit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 3),
+	warningTime: v.optional(TimeString, "23:30"),
+	blockMessage: v.optional(v.string(), "The agent is working. You can rest now and check results in the morning."),
+});
+export type AfterHoursConfig = v.InferOutput<typeof AfterHoursConfig>;
+
+// --- Config loading ---
+
+export function configPath(): string {
+	return join(process.env.HOME ?? "~", ".pi", "agent", "extensions", "pi-after-hours.json");
+}
+
+export function loadConfig(path = configPath()): AfterHoursConfig {
+	let raw: unknown = {};
+	try {
+		raw = JSON.parse(readFileSync(path, "utf-8"));
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw new Error(`after-hours: failed to read config at ${path}: ${err instanceof Error ? err.message : err}`);
+		}
+	}
+
+	try {
+		return v.parse(AfterHoursConfig, raw);
+	} catch (err) {
+		throw new Error(`after-hours: invalid config at ${path}: ${err instanceof Error ? err.message : err}`);
+	}
+}
+
+// --- Time helpers ---
+
+export function toMinutes(timeStr: string): number {
+	const [h, m] = timeStr.split(":").map(Number);
+	return h! * 60 + m!;
+}
+
+/** Check if a time (in minutes since midnight) falls within quiet hours. */
+export function isInQuietHours(now: number, start: number, end: number): boolean {
+	return start > end ? now >= start || now < end : now >= start && now < end;
+}
+
+/** Check if a time is past the warning threshold within quiet hours. */
+export function isPastWarningTime(now: number, warn: number, end: number, inQuiet: boolean): boolean {
+	if (!inQuiet) return false;
+	if (now < end && warn > end) return true;
+	return now >= warn;
+}

--- a/packages/after-hours/src/config.ts
+++ b/packages/after-hours/src/config.ts
@@ -16,13 +16,15 @@ export const AfterHoursConfig = v.object({
 	messageLimit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 3),
 	warningTime: v.optional(TimeString, "23:30"),
 	blockMessage: v.optional(v.string(), "The agent is working. You can rest now and check results in the morning."),
+	autoSleep: v.optional(v.boolean(), true),
+	autoSleepDelay: v.optional(v.pipe(v.number(), v.integer(), v.minValue(5), v.maxValue(300)), 30),
 });
 export type AfterHoursConfig = v.InferOutput<typeof AfterHoursConfig>;
 
 // --- Config loading ---
 
 export function configPath(): string {
-	return join(process.env.HOME ?? "~", ".pi", "agent", "extensions", "pi-after-hours.json");
+	return process.env.PI_AFTER_HOURS_CONFIG ?? join(process.env.HOME ?? "~", ".pi", "agent", "extensions", "pi-after-hours.json");
 }
 
 export function loadConfig(path = configPath()): AfterHoursConfig {

--- a/packages/after-hours/src/counter.ts
+++ b/packages/after-hours/src/counter.ts
@@ -1,0 +1,29 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface CounterState {
+	date: string; // YYYY-MM-DD
+	messagesUsed: number;
+}
+
+export function todayStr(now = new Date()): string {
+	return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+export function stateFilePath(date = todayStr()): string {
+	return join("/tmp", `pi-after-hours-${date}.json`);
+}
+
+export function loadCounter(today = todayStr()): CounterState {
+	try {
+		const state: CounterState = JSON.parse(readFileSync(stateFilePath(today), "utf-8"));
+		if (state.date === today) return state;
+	} catch {}
+	return { date: today, messagesUsed: 0 };
+}
+
+export function saveCounter(state: CounterState): void {
+	try {
+		writeFileSync(stateFilePath(state.date), JSON.stringify(state));
+	} catch {}
+}

--- a/packages/after-hours/src/index.ts
+++ b/packages/after-hours/src/index.ts
@@ -1,0 +1,258 @@
+/**
+ * After-Hours Message Limits — prevents hyperfocus-driven late-night agent sessions
+ * by implementing a message budget that gracefully interrupts the engagement loop.
+ *
+ * During quiet hours (default 23:00–07:00), the user gets a configurable number of
+ * messages (default 3). After the budget is spent, the UI is blocked with a
+ * full-screen terminal takeover until quiet hours end.
+ *
+ * Counter persists across sessions via a date-keyed state file in /tmp.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Text, matchesKey, visibleWidth } from "@mariozechner/pi-tui";
+
+import { type AfterHoursConfig, isInQuietHours, isPastWarningTime, loadConfig, toMinutes } from "./config.js";
+import { type CounterState, loadCounter, saveCounter, todayStr } from "./counter.js";
+
+export { AfterHoursConfig } from "./config.js";
+export type { CounterState } from "./counter.js";
+
+function nowMinutes(): number {
+	const d = new Date();
+	return d.getHours() * 60 + d.getMinutes();
+}
+
+function checkQuietHours(config: AfterHoursConfig): boolean {
+	return isInQuietHours(nowMinutes(), toMinutes(config.quietHoursStart), toMinutes(config.quietHoursEnd));
+}
+
+function checkWarningTime(config: AfterHoursConfig): boolean {
+	const now = nowMinutes();
+	const inQuiet = isInQuietHours(now, toMinutes(config.quietHoursStart), toMinutes(config.quietHoursEnd));
+	return isPastWarningTime(now, toMinutes(config.warningTime), toMinutes(config.quietHoursEnd), inQuiet);
+}
+
+export default function (pi: ExtensionAPI) {
+	let config: AfterHoursConfig;
+	try {
+		config = loadConfig();
+	} catch (err) {
+		// Log and bail — don't break pi if config is bad
+		console.error(err instanceof Error ? err.message : err);
+		return;
+	}
+
+	if (!config.enabled) return;
+
+	let counter = loadCounter();
+	let uiBlocked = false;
+	let widgetShown = false;
+	let currentCtx: ExtensionContext | null = null;
+	let warningCheckInterval: ReturnType<typeof setInterval> | null = null;
+
+	function remaining(): number {
+		return Math.max(0, config.messageLimit - counter.messagesUsed);
+	}
+
+	function refreshCounter(): void {
+		const today = todayStr();
+		if (counter.date !== today) {
+			counter = { date: today, messagesUsed: 0 };
+			saveCounter(counter);
+		}
+	}
+
+	function updateWidget(ctx: ExtensionContext): void {
+		if (!ctx.hasUI) return;
+		refreshCounter();
+
+		if (!checkQuietHours(config) || remaining() <= 0) {
+			if (widgetShown) {
+				ctx.ui.setWidget("after-hours", undefined);
+				widgetShown = false;
+			}
+			return;
+		}
+
+		if (checkWarningTime(config) || counter.messagesUsed > 0) {
+			const r = remaining();
+			const plural = r === 1 ? "message" : "messages";
+			ctx.ui.setWidget("after-hours", (_tui, theme) => {
+				return new Text(theme.fg("warning", `🌙 Quiet hours active. ${r} ${plural} remaining tonight.`), 0, 0);
+			});
+			widgetShown = true;
+		}
+	}
+
+	function blockUI(ctx: ExtensionContext): void {
+		if (!ctx.hasUI || uiBlocked) return;
+		uiBlocked = true;
+
+		ctx.ui.setWidget("after-hours", undefined);
+		ctx.ui.setStatus("after-hours", undefined);
+		widgetShown = false;
+
+		const msg = config.blockMessage;
+		const endTime = config.quietHoursEnd;
+
+		// Take over the terminal directly — stop the TUI, clear screen, render
+		// our own content with raw stdin handling. Same pattern as interactive-shell.
+		ctx.ui.custom<void>((tui, theme, _keybindings, done) => {
+			tui.stop();
+			process.stdout.write("\x1b[2J\x1b[H\x1b[?25l");
+
+			const renderBlock = () => {
+				const width = process.stdout.columns || 80;
+				const height = process.stdout.rows || 24;
+
+				const centerH = (s: string) => {
+					const pad = Math.max(0, Math.floor((width - visibleWidth(s)) / 2));
+					return " ".repeat(pad) + s;
+				};
+
+				const boxWidth = Math.min(60, width - 4);
+				const boxInner = boxWidth - 2;
+				const hBar = "─".repeat(boxInner);
+				const dim = (s: string) => theme.fg("dim", s);
+
+				const centerInBox = (s: string) => {
+					const totalPad = Math.max(0, boxInner - visibleWidth(s));
+					const left = Math.floor(totalPad / 2);
+					return dim("│") + " ".repeat(left) + s + " ".repeat(totalPad - left) + dim("│");
+				};
+				const emptyRow = centerInBox("");
+
+				const boxLines = [
+					dim(`╭${hBar}╮`),
+					emptyRow,
+					emptyRow,
+					centerInBox("🌙"),
+					emptyRow,
+					emptyRow,
+					centerInBox(msg),
+					emptyRow,
+					centerInBox(`Quiet hours end at ${endTime}`),
+					emptyRow,
+					emptyRow,
+					centerInBox(dim("Ctrl+C to exit")),
+					emptyRow,
+					emptyRow,
+					dim(`╰${hBar}╯`),
+				];
+
+				const lines: string[] = [];
+				const topPad = Math.max(0, Math.floor((height - boxLines.length) / 2));
+				for (let i = 0; i < topPad; i++) lines.push("");
+				for (const bl of boxLines) lines.push(centerH(bl));
+				while (lines.length < height) lines.push("");
+
+				const padded = lines.map((l) => l + " ".repeat(Math.max(0, width - visibleWidth(l))));
+				process.stdout.write(`\x1b[H${padded.join("\n")}`);
+			};
+
+			renderBlock();
+
+			const resizeHandler = () => renderBlock();
+			process.stdout.on("resize", resizeHandler);
+
+			const checkInterval = setInterval(() => {
+				refreshCounter();
+				if (!checkQuietHours(config)) cleanup();
+			}, 60_000);
+
+			const stdinHandler = (data: Buffer) => {
+				const str = data.toString();
+				if (matchesKey(str, "ctrl+c") || matchesKey(str, "ctrl+d")) {
+					cleanup();
+					ctx.shutdown();
+				}
+			};
+			if (process.stdin.readable) process.stdin.on("data", stdinHandler);
+
+			const cleanup = () => {
+				clearInterval(checkInterval);
+				process.stdout.removeListener("resize", resizeHandler);
+				if (process.stdin.readable) process.stdin.removeListener("data", stdinHandler);
+				uiBlocked = false;
+				process.stdout.write("\x1b[?25h\x1b[2J\x1b[H");
+				tui.start();
+				tui.requestRender(true);
+				done();
+			};
+
+			return { render: () => [], handleInput() {}, invalidate() {} };
+		});
+	}
+
+	// --- Events ---
+
+	pi.on("session_start", async (_event, ctx) => {
+		currentCtx = ctx;
+		refreshCounter();
+
+		if (checkQuietHours(config) && remaining() <= 0) {
+			blockUI(ctx);
+			return;
+		}
+
+		updateWidget(ctx);
+
+		if (warningCheckInterval) clearInterval(warningCheckInterval);
+		warningCheckInterval = setInterval(() => {
+			if (currentCtx) updateWidget(currentCtx);
+		}, 60_000);
+	});
+
+	pi.on("input", async (_event, ctx) => {
+		if (!config.enabled) return { action: "continue" as const };
+		refreshCounter();
+
+		if (!checkQuietHours(config)) return { action: "continue" as const };
+
+		if (remaining() <= 0) {
+			blockUI(ctx);
+			return { action: "handled" as const };
+		}
+
+		counter.messagesUsed++;
+		saveCounter(counter);
+
+		if (remaining() <= 0) {
+			ctx.ui.setWidget("after-hours", undefined);
+			widgetShown = false;
+			setTimeout(() => blockUI(ctx), 500);
+		} else {
+			updateWidget(ctx);
+		}
+
+		return { action: "continue" as const };
+	});
+
+	pi.on("session_shutdown", async () => {
+		if (warningCheckInterval) {
+			clearInterval(warningCheckInterval);
+			warningCheckInterval = null;
+		}
+		currentCtx = null;
+	});
+
+	pi.registerCommand("after-hours", {
+		description: "Show after-hours status",
+		handler: async (_args, ctx) => {
+			refreshCounter();
+			const inQuiet = checkQuietHours(config);
+			const r = remaining();
+			ctx.ui.notify(
+				[
+					`After-hours: ${config.enabled ? "enabled" : "disabled"}`,
+					`Quiet hours: ${config.quietHoursStart} – ${config.quietHoursEnd}`,
+					`Currently: ${inQuiet ? "in quiet hours" : "normal hours"}`,
+					`Budget: ${r}/${config.messageLimit} remaining`,
+					`Messages used tonight: ${counter.messagesUsed}`,
+				].join("\n"),
+				"info",
+			);
+		},
+	});
+}

--- a/packages/after-hours/src/index.ts
+++ b/packages/after-hours/src/index.ts
@@ -6,6 +6,10 @@
  * messages (default 3). After the budget is spent, the UI is blocked with a
  * full-screen terminal takeover until quiet hours end.
  *
+ * When auto-sleep is enabled (default), the block screen shows the agent's progress
+ * and starts a countdown to system suspend once the agent finishes. Any key cancels
+ * the countdown; Ctrl+C/Ctrl+D exits pi.
+ *
  * Counter persists across sessions via a date-keyed state file in /tmp.
  */
 
@@ -13,10 +17,12 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { Text, matchesKey, visibleWidth } from "@mariozechner/pi-tui";
 
 import { type AfterHoursConfig, isInQuietHours, isPastWarningTime, loadConfig, toMinutes } from "./config.js";
-import { type CounterState, loadCounter, saveCounter, todayStr } from "./counter.js";
+import { loadCounter, saveCounter, todayStr } from "./counter.js";
+import { suspendSystem } from "./sleep.js";
 
 export { AfterHoursConfig } from "./config.js";
 export type { CounterState } from "./counter.js";
+export { sleepCommand } from "./sleep.js";
 
 function nowMinutes(): number {
 	const d = new Date();
@@ -50,6 +56,13 @@ export default function (pi: ExtensionAPI) {
 	let widgetShown = false;
 	let currentCtx: ExtensionContext | null = null;
 	let warningCheckInterval: ReturnType<typeof setInterval> | null = null;
+
+	// Auto-sleep state — shared between blockUI and agent_end handler
+	let agentDone = false;
+	let sleepCountdown = -1; // -1 = not started, 0+ = seconds remaining
+	let sleepCancelled = false;
+	let countdownInterval: ReturnType<typeof setInterval> | null = null;
+	let blockRenderFn: (() => void) | null = null;
 
 	function remaining(): number {
 		return Math.max(0, config.messageLimit - counter.messagesUsed);
@@ -85,9 +98,40 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
+	function startSleepCountdown(): void {
+		if (!config.autoSleep || sleepCancelled || countdownInterval) return;
+		sleepCountdown = config.autoSleepDelay;
+		blockRenderFn?.();
+		countdownInterval = setInterval(() => {
+			sleepCountdown--;
+			blockRenderFn?.();
+			if (sleepCountdown <= 0) {
+				if (countdownInterval) clearInterval(countdownInterval);
+				countdownInterval = null;
+				suspendSystem();
+			}
+		}, 1000);
+	}
+
+	function cancelSleepCountdown(): void {
+		sleepCancelled = true;
+		if (countdownInterval) {
+			clearInterval(countdownInterval);
+			countdownInterval = null;
+		}
+		sleepCountdown = -1;
+		blockRenderFn?.();
+	}
+
 	function blockUI(ctx: ExtensionContext): void {
 		if (!ctx.hasUI || uiBlocked) return;
 		uiBlocked = true;
+
+		// Reset auto-sleep state for this block session
+		agentDone = false;
+		sleepCountdown = -1;
+		sleepCancelled = false;
+		countdownInterval = null;
 
 		ctx.ui.setWidget("after-hours", undefined);
 		ctx.ui.setStatus("after-hours", undefined);
@@ -95,6 +139,7 @@ export default function (pi: ExtensionAPI) {
 
 		const msg = config.blockMessage;
 		const endTime = config.quietHoursEnd;
+		const showAutoSleep = config.autoSleep;
 
 		// Take over the terminal directly — stop the TUI, clear screen, render
 		// our own content with raw stdin handling. Same pattern as interactive-shell.
@@ -123,23 +168,44 @@ export default function (pi: ExtensionAPI) {
 				};
 				const emptyRow = centerInBox("");
 
+				// Build sleep status line
+				let sleepLine: string;
+				if (!showAutoSleep) {
+					sleepLine = "";
+				} else if (sleepCancelled) {
+					sleepLine = dim("Auto-sleep disabled");
+				} else if (!agentDone) {
+					sleepLine = theme.fg("warning", "🔄 Agent is still working…");
+				} else if (sleepCountdown > 0) {
+					sleepLine = theme.fg("warning", `💤 Computer will sleep in ${sleepCountdown}s`);
+				} else {
+					sleepLine = theme.fg("warning", "💤 Suspending…");
+				}
+
+				// Build hint line
+				let hintLine: string;
+				if (showAutoSleep && !sleepCancelled && agentDone && sleepCountdown > 0) {
+					hintLine = dim("Press any key to cancel  •  Ctrl+C to exit");
+				} else {
+					hintLine = dim("Ctrl+C to exit");
+				}
+
 				const boxLines = [
 					dim(`╭${hBar}╮`),
 					emptyRow,
-					emptyRow,
 					centerInBox("🌙"),
-					emptyRow,
 					emptyRow,
 					centerInBox(msg),
 					emptyRow,
 					centerInBox(`Quiet hours end at ${endTime}`),
 					emptyRow,
-					emptyRow,
-					centerInBox(dim("Ctrl+C to exit")),
-					emptyRow,
-					emptyRow,
-					dim(`╰${hBar}╯`),
 				];
+
+				if (showAutoSleep && sleepLine) {
+					boxLines.push(centerInBox(sleepLine), emptyRow);
+				}
+
+				boxLines.push(centerInBox(hintLine), emptyRow, dim(`╰${hBar}╯`));
 
 				const lines: string[] = [];
 				const topPad = Math.max(0, Math.floor((height - boxLines.length) / 2));
@@ -147,10 +213,11 @@ export default function (pi: ExtensionAPI) {
 				for (const bl of boxLines) lines.push(centerH(bl));
 				while (lines.length < height) lines.push("");
 
-				const padded = lines.map((l) => l + " ".repeat(Math.max(0, width - visibleWidth(l))));
+				const padded = lines.map((l) => `${l}${" ".repeat(Math.max(0, width - visibleWidth(l)))}`);
 				process.stdout.write(`\x1b[H${padded.join("\n")}`);
 			};
 
+			blockRenderFn = renderBlock;
 			renderBlock();
 
 			const resizeHandler = () => renderBlock();
@@ -166,14 +233,30 @@ export default function (pi: ExtensionAPI) {
 				if (matchesKey(str, "ctrl+c") || matchesKey(str, "ctrl+d")) {
 					cleanup();
 					ctx.shutdown();
+					return;
+				}
+				// Any other key cancels auto-sleep countdown
+				if (showAutoSleep && !sleepCancelled) {
+					cancelSleepCountdown();
 				}
 			};
 			if (process.stdin.readable) process.stdin.on("data", stdinHandler);
 
+			// If agent is already done when block starts (e.g. messageLimit=0),
+			// start countdown immediately
+			if (agentDone && showAutoSleep) {
+				startSleepCountdown();
+			}
+
 			const cleanup = () => {
 				clearInterval(checkInterval);
+				if (countdownInterval) {
+					clearInterval(countdownInterval);
+					countdownInterval = null;
+				}
 				process.stdout.removeListener("resize", resizeHandler);
 				if (process.stdin.readable) process.stdin.removeListener("data", stdinHandler);
+				blockRenderFn = null;
 				uiBlocked = false;
 				process.stdout.write("\x1b[?25h\x1b[2J\x1b[H");
 				tui.start();
@@ -192,6 +275,8 @@ export default function (pi: ExtensionAPI) {
 		refreshCounter();
 
 		if (checkQuietHours(config) && remaining() <= 0) {
+			// Agent is idle at session start — mark done immediately
+			agentDone = true;
 			blockUI(ctx);
 			return;
 		}
@@ -229,10 +314,25 @@ export default function (pi: ExtensionAPI) {
 		return { action: "continue" as const };
 	});
 
+	pi.on("agent_end", async () => {
+		if (!uiBlocked) return;
+		agentDone = true;
+		// If block screen is up and auto-sleep is enabled, start countdown
+		if (config.autoSleep && !sleepCancelled) {
+			startSleepCountdown();
+		} else {
+			blockRenderFn?.();
+		}
+	});
+
 	pi.on("session_shutdown", async () => {
 		if (warningCheckInterval) {
 			clearInterval(warningCheckInterval);
 			warningCheckInterval = null;
+		}
+		if (countdownInterval) {
+			clearInterval(countdownInterval);
+			countdownInterval = null;
 		}
 		currentCtx = null;
 	});
@@ -250,6 +350,7 @@ export default function (pi: ExtensionAPI) {
 					`Currently: ${inQuiet ? "in quiet hours" : "normal hours"}`,
 					`Budget: ${r}/${config.messageLimit} remaining`,
 					`Messages used tonight: ${counter.messagesUsed}`,
+					`Auto-sleep: ${config.autoSleep ? `enabled (${config.autoSleepDelay}s)` : "disabled"}`,
 				].join("\n"),
 				"info",
 			);

--- a/packages/after-hours/src/sleep.ts
+++ b/packages/after-hours/src/sleep.ts
@@ -1,0 +1,26 @@
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+
+/** Return the platform-appropriate suspend command. */
+export function sleepCommand(os = platform()): string {
+	switch (os) {
+		case "darwin":
+			return "pmset sleepnow";
+		case "linux":
+			return "systemctl suspend";
+		default:
+			return "";
+	}
+}
+
+/** Put the computer to sleep. Returns true if the command was issued. */
+export function suspendSystem(os = platform()): boolean {
+	const cmd = sleepCommand(os);
+	if (!cmd) return false;
+	try {
+		execSync(cmd, { stdio: "ignore", timeout: 5000 });
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/after-hours/test/config.test.ts
+++ b/packages/after-hours/test/config.test.ts
@@ -1,0 +1,134 @@
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import { AfterHoursConfig, isInQuietHours, isPastWarningTime, toMinutes } from "../src/config.js";
+
+describe("AfterHoursConfig schema", () => {
+	it("parses empty object with defaults", () => {
+		const result = v.parse(AfterHoursConfig, {});
+		expect(result.enabled).toBe(true);
+		expect(result.quietHoursStart).toBe("23:00");
+		expect(result.quietHoursEnd).toBe("07:00");
+		expect(result.messageLimit).toBe(3);
+		expect(result.warningTime).toBe("23:30");
+		expect(result.blockMessage).toContain("rest now");
+	});
+
+	it("parses full config", () => {
+		const result = v.parse(AfterHoursConfig, {
+			enabled: false,
+			quietHoursStart: "22:00",
+			quietHoursEnd: "06:00",
+			messageLimit: 5,
+			warningTime: "22:30",
+			blockMessage: "Go to sleep!",
+		});
+		expect(result.enabled).toBe(false);
+		expect(result.quietHoursStart).toBe("22:00");
+		expect(result.quietHoursEnd).toBe("06:00");
+		expect(result.messageLimit).toBe(5);
+		expect(result.warningTime).toBe("22:30");
+		expect(result.blockMessage).toBe("Go to sleep!");
+	});
+
+	it("rejects invalid time format", () => {
+		expect(() => v.parse(AfterHoursConfig, { quietHoursStart: "9pm" })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { quietHoursStart: "25:00" })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { quietHoursStart: "9:00" })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { quietHoursStart: "23:60" })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { quietHoursStart: "99:99" })).toThrow();
+	});
+
+	it("accepts boundary time values", () => {
+		expect(v.parse(AfterHoursConfig, { quietHoursStart: "00:00" }).quietHoursStart).toBe("00:00");
+		expect(v.parse(AfterHoursConfig, { quietHoursStart: "23:59" }).quietHoursStart).toBe("23:59");
+	});
+
+	it("allows messageLimit of 0 (immediate block)", () => {
+		const result = v.parse(AfterHoursConfig, { messageLimit: 0 });
+		expect(result.messageLimit).toBe(0);
+	});
+
+	it("rejects negative messageLimit", () => {
+		expect(() => v.parse(AfterHoursConfig, { messageLimit: -1 })).toThrow();
+	});
+
+	it("rejects non-integer messageLimit", () => {
+		expect(() => v.parse(AfterHoursConfig, { messageLimit: 2.5 })).toThrow();
+	});
+
+	it("allows partial config", () => {
+		const result = v.parse(AfterHoursConfig, { messageLimit: 10 });
+		expect(result.messageLimit).toBe(10);
+		expect(result.quietHoursStart).toBe("23:00"); // default preserved
+	});
+});
+
+describe("toMinutes", () => {
+	it("converts HH:MM to minutes since midnight", () => {
+		expect(toMinutes("00:00")).toBe(0);
+		expect(toMinutes("23:00")).toBe(23 * 60);
+		expect(toMinutes("07:30")).toBe(7 * 60 + 30);
+		expect(toMinutes("12:00")).toBe(720);
+	});
+});
+
+describe("isInQuietHours", () => {
+	it("handles same-day range (e.g. 01:00–06:00)", () => {
+		const start = toMinutes("01:00");
+		const end = toMinutes("06:00");
+		expect(isInQuietHours(toMinutes("00:30"), start, end)).toBe(false);
+		expect(isInQuietHours(toMinutes("01:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("03:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("05:59"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("06:00"), start, end)).toBe(false);
+		expect(isInQuietHours(toMinutes("23:00"), start, end)).toBe(false);
+	});
+
+	it("handles midnight-crossing range (e.g. 23:00–07:00)", () => {
+		const start = toMinutes("23:00");
+		const end = toMinutes("07:00");
+		expect(isInQuietHours(toMinutes("22:59"), start, end)).toBe(false);
+		expect(isInQuietHours(toMinutes("23:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("23:59"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("00:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("03:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("06:59"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("07:00"), start, end)).toBe(false);
+		expect(isInQuietHours(toMinutes("12:00"), start, end)).toBe(false);
+	});
+
+	it("handles full-day range (e.g. 00:00–23:59)", () => {
+		const start = toMinutes("00:00");
+		const end = toMinutes("23:59");
+		expect(isInQuietHours(toMinutes("00:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("12:00"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("23:58"), start, end)).toBe(true);
+		expect(isInQuietHours(toMinutes("23:59"), start, end)).toBe(false); // end is exclusive
+	});
+});
+
+describe("isPastWarningTime", () => {
+	it("returns false when not in quiet hours", () => {
+		expect(isPastWarningTime(toMinutes("12:00"), toMinutes("23:30"), toMinutes("07:00"), false)).toBe(false);
+	});
+
+	it("returns true when past warning in same-evening portion", () => {
+		// 23:45, warning at 23:30, end at 07:00, in quiet hours
+		expect(isPastWarningTime(toMinutes("23:45"), toMinutes("23:30"), toMinutes("07:00"), true)).toBe(true);
+	});
+
+	it("returns false when before warning in same-evening portion", () => {
+		// 23:15, warning at 23:30, end at 07:00, in quiet hours
+		expect(isPastWarningTime(toMinutes("23:15"), toMinutes("23:30"), toMinutes("07:00"), true)).toBe(false);
+	});
+
+	it("returns true in early morning (after midnight, warning was previous evening)", () => {
+		// 02:00, warning at 23:30, end at 07:00, in quiet hours
+		expect(isPastWarningTime(toMinutes("02:00"), toMinutes("23:30"), toMinutes("07:00"), true)).toBe(true);
+	});
+
+	it("handles warning same as start", () => {
+		// Warning at 23:00, currently 23:00
+		expect(isPastWarningTime(toMinutes("23:00"), toMinutes("23:00"), toMinutes("07:00"), true)).toBe(true);
+	});
+});

--- a/packages/after-hours/test/config.test.ts
+++ b/packages/after-hours/test/config.test.ts
@@ -11,6 +11,8 @@ describe("AfterHoursConfig schema", () => {
 		expect(result.messageLimit).toBe(3);
 		expect(result.warningTime).toBe("23:30");
 		expect(result.blockMessage).toContain("rest now");
+		expect(result.autoSleep).toBe(true);
+		expect(result.autoSleepDelay).toBe(30);
 	});
 
 	it("parses full config", () => {
@@ -21,6 +23,8 @@ describe("AfterHoursConfig schema", () => {
 			messageLimit: 5,
 			warningTime: "22:30",
 			blockMessage: "Go to sleep!",
+			autoSleep: false,
+			autoSleepDelay: 60,
 		});
 		expect(result.enabled).toBe(false);
 		expect(result.quietHoursStart).toBe("22:00");
@@ -28,6 +32,8 @@ describe("AfterHoursConfig schema", () => {
 		expect(result.messageLimit).toBe(5);
 		expect(result.warningTime).toBe("22:30");
 		expect(result.blockMessage).toBe("Go to sleep!");
+		expect(result.autoSleep).toBe(false);
+		expect(result.autoSleepDelay).toBe(60);
 	});
 
 	it("rejects invalid time format", () => {
@@ -54,6 +60,25 @@ describe("AfterHoursConfig schema", () => {
 
 	it("rejects non-integer messageLimit", () => {
 		expect(() => v.parse(AfterHoursConfig, { messageLimit: 2.5 })).toThrow();
+	});
+
+	it("rejects autoSleepDelay below minimum", () => {
+		expect(() => v.parse(AfterHoursConfig, { autoSleepDelay: 4 })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { autoSleepDelay: 0 })).toThrow();
+		expect(() => v.parse(AfterHoursConfig, { autoSleepDelay: -1 })).toThrow();
+	});
+
+	it("rejects autoSleepDelay above maximum", () => {
+		expect(() => v.parse(AfterHoursConfig, { autoSleepDelay: 301 })).toThrow();
+	});
+
+	it("accepts autoSleepDelay at boundaries", () => {
+		expect(v.parse(AfterHoursConfig, { autoSleepDelay: 5 }).autoSleepDelay).toBe(5);
+		expect(v.parse(AfterHoursConfig, { autoSleepDelay: 300 }).autoSleepDelay).toBe(300);
+	});
+
+	it("rejects non-integer autoSleepDelay", () => {
+		expect(() => v.parse(AfterHoursConfig, { autoSleepDelay: 10.5 })).toThrow();
 	});
 
 	it("allows partial config", () => {

--- a/packages/after-hours/test/counter.test.ts
+++ b/packages/after-hours/test/counter.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadCounter, saveCounter, stateFilePath, todayStr } from "../src/counter.js";
+
+describe("todayStr", () => {
+	it("formats as YYYY-MM-DD", () => {
+		const result = todayStr(new Date(2026, 2, 11)); // March 11, 2026
+		expect(result).toBe("2026-03-11");
+	});
+
+	it("pads single-digit months and days", () => {
+		const result = todayStr(new Date(2026, 0, 5)); // Jan 5, 2026
+		expect(result).toBe("2026-01-05");
+	});
+});
+
+describe("counter persistence", () => {
+	const testDate = "2099-01-01";
+	const testPath = stateFilePath(testDate);
+
+	afterEach(() => {
+		try {
+			unlinkSync(testPath);
+		} catch {}
+	});
+
+	it("returns fresh counter when no file exists", () => {
+		const counter = loadCounter(testDate);
+		expect(counter).toEqual({ date: testDate, messagesUsed: 0 });
+	});
+
+	it("round-trips through save and load", () => {
+		const state = { date: testDate, messagesUsed: 3 };
+		saveCounter(state);
+		expect(existsSync(testPath)).toBe(true);
+
+		const loaded = loadCounter(testDate);
+		expect(loaded).toEqual(state);
+	});
+
+	it("returns fresh counter when file has wrong date", () => {
+		writeFileSync(testPath, JSON.stringify({ date: "2098-12-31", messagesUsed: 5 }));
+		const counter = loadCounter(testDate);
+		expect(counter).toEqual({ date: testDate, messagesUsed: 0 });
+	});
+
+	it("returns fresh counter when file is corrupt", () => {
+		writeFileSync(testPath, "not json");
+		const counter = loadCounter(testDate);
+		expect(counter).toEqual({ date: testDate, messagesUsed: 0 });
+	});
+});

--- a/packages/after-hours/test/sleep.test.ts
+++ b/packages/after-hours/test/sleep.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { sleepCommand } from "../src/sleep.js";
+
+describe("sleepCommand", () => {
+	it("returns systemctl suspend for linux", () => {
+		expect(sleepCommand("linux")).toBe("systemctl suspend");
+	});
+
+	it("returns pmset sleepnow for darwin", () => {
+		expect(sleepCommand("darwin")).toBe("pmset sleepnow");
+	});
+
+	it("returns empty string for unsupported platforms", () => {
+		expect(sleepCommand("win32")).toBe("");
+		expect(sleepCommand("freebsd")).toBe("");
+	});
+});

--- a/packages/after-hours/tsconfig.json
+++ b/packages/after-hours/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/after-hours/tsup.config.ts
+++ b/packages/after-hours/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	external: ["@mariozechner/pi-coding-agent", "@mariozechner/pi-tui"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4407,6 +4407,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pi-after-hours@workspace:packages/after-hours":
+  version: 0.0.0-use.local
+  resolution: "pi-after-hours@workspace:packages/after-hours"
+  dependencies:
+    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-tui": "npm:^0.57.0"
+    "@types/node": "npm:^25.3.5"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^5.9.3"
+    valibot: "npm:^1.2.0"
+  peerDependencies:
+    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-tui": "*"
+  languageName: unknown
+  linkType: soft
+
 "pi-bash-trim@workspace:packages/bash-trim":
   version: 0.0.0-use.local
   resolution: "pi-bash-trim@workspace:packages/bash-trim"


### PR DESCRIPTION
Message budget for quiet hours — break the late-night engagement loop.

During quiet hours (default 23:00–07:00), the user gets a configurable number of messages (default 3). After the budget is spent, pi's UI is blocked with a full-screen terminal takeover until quiet hours end.

## Features

- **Valibot config schema** with strict time validation (HH:MM, 00:00–23:59)
- **Message counter** persisted in `/tmp` (ephemeral across reboots — intentional)
- **`messageLimit: 0`** for immediate block on quiet hours entry
- **Full-screen block** with centered box, auto-dismiss when quiet hours end
- **Widget banner** showing remaining message count
- **`/after-hours` command** for status check

## Config

`~/.pi/agent/extensions/pi-after-hours.json`:
```json
{
  "quietHoursStart": "23:00",
  "quietHoursEnd": "07:00",
  "messageLimit": 3,
  "warningTime": "23:30"
}
```

## Tests

23 tests covering config validation (schema defaults, time format rejection, boundary values), time logic (midnight crossing, same-day ranges, warning time), and counter persistence (round-trip, corruption, date mismatch).