### PR TITLE
feat: add pi-no-soft-cursor extension package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Monorepo of extensions and libraries for [pi](https://pi.dev). Managed with Yarn
 | pi-bash-trim | `packages/bash-trim/` | pi extension |
 | pi-desktop-notify | `packages/desktop-notify/` | pi extension + library |
 | pi-budget-model | `packages/budget-model/` | library |
+| pi-no-soft-cursor | `packages/no-soft-cursor/` | pi extension |
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities for running [pi](https://pi.dev) agents with less babysitting: auto-re
 Install the extensions together, or pick only the ones you want. Defaults are tuned for good behavior out of the box.
 
 ```bash
-pi install pi-safeguard pi-bash-trim pi-desktop-notify
+pi install pi-safeguard pi-bash-trim pi-desktop-notify pi-no-soft-cursor
 ```
 
 ### [pi-safeguard](packages/safeguard/)
@@ -25,6 +25,10 @@ Smart bash output trimming. Intercepts tool results before they enter the contex
 ### [pi-desktop-notify](packages/desktop-notify/)
 
 Desktop notifications with terminal focus tracking. Notifications are suppressed while the terminal is in the foreground and only fire when you've tabbed away — so you hear about finished tasks without being interrupted mid-thought. Click-to-focus brings the terminal back. Works on macOS (terminal-notifier) and Linux (notify-send), with compositor support for niri, sway, and hyprland.
+
+### [pi-no-soft-cursor](packages/no-soft-cursor/)
+
+Remove the reverse-video block cursor from the editor. Your terminal already shows a blinking cursor via the hardware cursor marker — the highlighted character block the editor draws on top is just visual noise. This strips it.
 
 ## Libraries
 

--- a/packages/no-soft-cursor/README.md
+++ b/packages/no-soft-cursor/README.md
@@ -1,0 +1,28 @@
+# pi-no-soft-cursor
+
+Remove the reverse-video block cursor from pi's editor. Your terminal's native blinking cursor still shows the insertion point — just without the highlighted character block drawn on top.
+
+## Install
+
+```bash
+pi install npm:pi-no-soft-cursor
+```
+
+## What it does
+
+Pi's text editor renders a "soft cursor": the character under the cursor is shown in reverse video (a highlighted block). Some terminals already show a blinking cursor via the hardware cursor marker, making the soft cursor redundant or visually noisy.
+
+This extension:
+
+1. **Strips the soft cursor** — subclasses the editor and removes the last reverse-video span from each rendered line (the one the editor uses for the cursor block).
+2. **Forces the hardware cursor on** — pi has a "Show hardware cursor" setting that is off by default. This extension enables it unconditionally so the terminal's native cursor is always visible.
+
+> **Note:** With this extension active, pi's "Show hardware cursor" setting has no effect — the hardware cursor is always enabled.
+
+## Setup
+
+After installing, **restart pi** for the extension to take effect. `/reload` alone is not sufficient due to a limitation in how pi manages the editor component during reload.
+
+## Configuration
+
+None. Install and it works.

--- a/packages/no-soft-cursor/package.json
+++ b/packages/no-soft-cursor/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "pi-no-soft-cursor",
+	"version": "1.0.0",
+	"description": "Remove the editor's reverse-video soft cursor — use only the terminal's native cursor",
+	"author": "mgabor3141",
+	"license": "MIT",
+	"repository": {
+		"url": "git+https://github.com/mgabor3141/yapp.git",
+		"directory": "packages/no-soft-cursor"
+	},
+	"keywords": [
+		"pi-package",
+		"editor",
+		"cursor",
+		"tui"
+	],
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsup"
+	},
+	"pi": {
+		"extensions": [
+			"dist/index.js"
+		]
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "*",
+		"@mariozechner/pi-tui": "*"
+	},
+	"devDependencies": {
+		"@mariozechner/pi-coding-agent": "^0.57.0",
+		"@mariozechner/pi-tui": "^0.57.0",
+		"@types/node": "^25.3.5",
+		"tsup": "^8.5.1",
+		"typescript": "^5.9.3"
+	}
+}

--- a/packages/no-soft-cursor/src/index.ts
+++ b/packages/no-soft-cursor/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * pi-no-soft-cursor — remove the editor's reverse-video "fake" cursor.
+ *
+ * The terminal's native (hardware) cursor is forced on so you still see
+ * a blinking caret at the insertion point. Only the highlighted block that
+ * the editor draws on top is removed.
+ *
+ * Note: with this extension active, pi's "Show hardware cursor" setting
+ * has no effect — the hardware cursor is always enabled.
+ */
+
+import { CustomEditor, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+import { stripSoftCursor } from "./strip.js";
+
+class NoCursorEditor extends CustomEditor {
+	constructor(...args: ConstructorParameters<typeof CustomEditor>) {
+		super(...args);
+		this.tui.setShowHardwareCursor(true);
+	}
+
+	render(width: number): string[] {
+		return super.render(width).map(stripSoftCursor);
+	}
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		ctx.ui.setEditorComponent((tui, theme, kb) => new NoCursorEditor(tui, theme, kb));
+	});
+}

--- a/packages/no-soft-cursor/src/strip.ts
+++ b/packages/no-soft-cursor/src/strip.ts
@@ -1,0 +1,27 @@
+const REVERSE_ON = "\x1b[7m";
+const REVERSE_OFF = "\x1b[0m";
+
+/**
+ * Strip the *last* reverse-video span (`\x1b[7m…\x1b[0m`) from a string,
+ * keeping the inner content. Only the final occurrence is removed — this
+ * targets the editor's soft cursor (which is always at the cursor position,
+ * i.e. the last such span on the line) without disturbing any earlier
+ * reverse-video markup.
+ */
+export function stripSoftCursor(line: string): string {
+	const revEnd = line.lastIndexOf(REVERSE_OFF);
+	if (revEnd === -1) return line;
+
+	const revStart = line.lastIndexOf(REVERSE_ON, revEnd);
+	if (revStart === -1) return line;
+
+	// Make sure this pair is well-formed (no nested open between them)
+	const contentStart = revStart + REVERSE_ON.length;
+	if (contentStart > revEnd) return line;
+
+	const before = line.slice(0, revStart);
+	const content = line.slice(contentStart, revEnd);
+	const after = line.slice(revEnd + REVERSE_OFF.length);
+
+	return before + content + after;
+}

--- a/packages/no-soft-cursor/test/strip.test.ts
+++ b/packages/no-soft-cursor/test/strip.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { stripSoftCursor } from "../src/strip.js";
+
+const REV = "\x1b[7m";
+const RST = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const FG = "\x1b[38;2;100;100;100m";
+
+describe("stripSoftCursor", () => {
+	// --- passthrough cases ---
+
+	it("passes plain text through unchanged", () => {
+		expect(stripSoftCursor("hello world")).toBe("hello world");
+	});
+
+	it("passes empty string through", () => {
+		expect(stripSoftCursor("")).toBe("");
+	});
+
+	it("returns line unchanged when reverse-on has no matching close", () => {
+		expect(stripSoftCursor(`before${REV}dangling`)).toBe(`before${REV}dangling`);
+	});
+
+	it("returns line unchanged when only reset exists (no reverse-on)", () => {
+		expect(stripSoftCursor(`text${RST}more`)).toBe(`text${RST}more`);
+	});
+
+	// --- basic stripping ---
+
+	it("strips a single reverse-video span", () => {
+		expect(stripSoftCursor(`before${REV}X${RST}after`)).toBe("beforeXafter");
+	});
+
+	it("strips reverse-video span with multi-char content", () => {
+		expect(stripSoftCursor(`${REV}hello${RST}`)).toBe("hello");
+	});
+
+	it("strips reverse-video around a space (end-of-line cursor)", () => {
+		expect(stripSoftCursor(`text${REV} ${RST}`)).toBe("text ");
+	});
+
+	it("strips reverse-video around unicode grapheme", () => {
+		expect(stripSoftCursor(`${REV}🚀${RST}`)).toBe("🚀");
+	});
+
+	it("handles line with only reverse-video", () => {
+		expect(stripSoftCursor(`${REV}X${RST}`)).toBe("X");
+	});
+
+	// --- last-only behavior ---
+
+	it("strips only the last reverse-video span when multiple exist", () => {
+		const input = `${REV}A${RST} gap ${REV}B${RST}`;
+		expect(stripSoftCursor(input)).toBe(`${REV}A${RST} gap B`);
+	});
+
+	it("handles adjacent reverse-video spans — strips only last", () => {
+		expect(stripSoftCursor(`${REV}A${RST}${REV}B${RST}`)).toBe(`${REV}A${RST}B`);
+	});
+
+	it("preserves earlier reverse-video in a line with cursor at end", () => {
+		const line = `${REV}label${RST}: value${REV}X${RST}`;
+		expect(stripSoftCursor(line)).toBe(`${REV}label${RST}: valueX`);
+	});
+
+	// --- interaction with other ANSI sequences ---
+
+	it("preserves bold+reset before the cursor span", () => {
+		const input = `${BOLD}bold${RST} ${REV}X${RST} plain`;
+		expect(stripSoftCursor(input)).toBe(`${BOLD}bold${RST} X plain`);
+	});
+
+	it("handles a reset after the cursor span (known boundary)", () => {
+		// If a \x1b[0m appears after the cursor's \x1b[0m on the same line, the
+		// function matches the outer pair: last REV to last RST.  This eats the
+		// inner reset and any color opener, but the visible text is preserved.
+		// In practice the editor never emits color sequences after the cursor on
+		// content lines, so this path doesn't fire — we test it to document the
+		// boundary and confirm no text is lost.
+		const input = `${REV}X${RST}${FG}colored${RST}`;
+		// Strips from REV(0) to final RST — inner resets and FG become "content"
+		expect(stripSoftCursor(input)).toBe(`X${RST}${FG}colored`);
+	});
+
+	it("handles color-only lines without reverse-video (border lines)", () => {
+		// borderColor wraps produce \x1b[38;2;…m…\x1b[0m but no \x1b[7m
+		const border = `${FG}${"─".repeat(40)}${RST}`;
+		expect(stripSoftCursor(border)).toBe(border);
+	});
+
+	it("handles dim color wrapping border indicators", () => {
+		const indicator = `${DIM}─── ↑ 3 more ${RST}${"─".repeat(20)}`;
+		expect(stripSoftCursor(indicator)).toBe(indicator);
+	});
+
+	// --- realistic editor output ---
+
+	it("handles content line: padding + text + cursor + padding", () => {
+		// Editor renders: "  hello[cursor:w]orld        "
+		const line = `  hello${REV}w${RST}orld${"  ".repeat(5)}`;
+		expect(stripSoftCursor(line)).toBe(`  helloworld${"  ".repeat(5)}`);
+	});
+
+	it("handles content line: cursor at end of text + padding", () => {
+		// Editor renders: "  hello[cursor: ]        "
+		const line = `  hello${REV} ${RST}${"  ".repeat(5)}`;
+		expect(stripSoftCursor(line)).toBe(`  hello ${"  ".repeat(5)}`);
+	});
+
+	it("handles content line with hardware cursor marker before soft cursor", () => {
+		// The hardware cursor marker is a zero-width APC sequence placed before the soft cursor
+		const CURSOR_MARKER = "\x1b_pi:c\x07";
+		const line = `  hello${CURSOR_MARKER}${REV}w${RST}orld  `;
+		expect(stripSoftCursor(line)).toBe(`  hello${CURSOR_MARKER}world  `);
+	});
+});

--- a/packages/no-soft-cursor/tsconfig.json
+++ b/packages/no-soft-cursor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"]
+}

--- a/packages/no-soft-cursor/tsup.config.ts
+++ b/packages/no-soft-cursor/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	external: ["@mariozechner/pi-coding-agent", "@mariozechner/pi-tui"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,6 +4454,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"pi-no-soft-cursor@workspace:packages/no-soft-cursor":
+  version: 0.0.0-use.local
+  resolution: "pi-no-soft-cursor@workspace:packages/no-soft-cursor"
+  dependencies:
+    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-tui": "npm:^0.57.0"
+    "@types/node": "npm:^25.3.5"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^5.9.3"
+  peerDependencies:
+    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-tui": "*"
+  languageName: unknown
+  linkType: soft
+
 "pi-safeguard@workspace:packages/safeguard":
   version: 0.0.0-use.local
   resolution: "pi-safeguard@workspace:packages/safeguard"


### PR DESCRIPTION
Strips the editor's reverse-video soft cursor and forces the terminal's native hardware cursor on.

## What's new

**`pi-no-soft-cursor`** — a new extension that:

1. Removes the last reverse-video span from each rendered editor line (the soft cursor block)
2. Enables the terminal's hardware cursor unconditionally in the constructor

With this extension, pi's "Show hardware cursor" setting has no effect — the hardware cursor is always on.

## Package contents

- `src/strip.ts` — `stripSoftCursor()`: finds the last `\x1b[7m…\x1b[0m` span and unwraps it
- `src/index.ts` — `NoCursorEditor` subclass of `CustomEditor`
- `test/strip.test.ts` — 14 tests
- README, package.json, build config

First version (`1.0.0`) — needs manual `npm publish` after merge.