### PR TITLE
docs: document first-publish workflow, add npm: prefix to install commands

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,14 +70,28 @@ Multiple PRs with changesets accumulate — the Version Packages PR collects the
 
 Review the version bumps and changelog entries, then merge. The workflow runs again and publishes new versions to npm via OIDC using `yarn npm publish`.
 
-### Trusted publishing
+### New packages — first publish
 
-The release workflow uses GitHub Actions OIDC (`id-token: write` permission) to authenticate with npm. No `NPM_TOKEN` secret is needed. Each package must have a trusted publisher configured on npmjs.com:
+OIDC trusted publishing only works for packages that already exist on npm. The very first version of a new package must be published manually:
 
-- **Owner:** `mgabor3141`
-- **Repository:** `yapp`
-- **Workflow:** `release.yml`
-- **Environment:** (blank)
+```bash
+npm login                  # one-time, if not already logged in
+cd packages/<new-package>
+npm publish --access public
+cd ../..
+```
+
+Then configure trusted publishing on npmjs.com so CI can handle subsequent releases:
+
+1. Go to **npmjs.com → package → Settings → Publishing access**
+2. Under **Trusted publishers**, add:
+   - **Owner:** `mgabor3141`
+   - **Repository:** `yapp`
+   - **Workflow:** `release.yml`
+   - **Environment:** (blank)
+3. Set `Require two-factor authentication and disallow tokens`
+
+After this, the changeset workflow handles all future versions.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities for running [pi](https://pi.dev) agents with less babysitting: auto-re
 Install the extensions together, or pick only the ones you want. Defaults are tuned for good behavior out of the box.
 
 ```bash
-pi install pi-safeguard pi-bash-trim pi-desktop-notify pi-no-soft-cursor
+pi install npm:pi-safeguard npm:pi-bash-trim npm:pi-desktop-notify npm:pi-no-soft-cursor
 ```
 
 ### [pi-safeguard](packages/safeguard/)

--- a/packages/bash-trim/README.md
+++ b/packages/bash-trim/README.md
@@ -5,7 +5,7 @@
 Smart bash output trimming for [pi](https://pi.dev). Keeps context lean so the agent spends tokens on thinking, not on scrolling past 2000 lines of build output.
 
 ```bash
-pi install pi-bash-trim
+pi install npm:pi-bash-trim
 ```
 
 No configuration needed.

--- a/packages/desktop-notify/README.md
+++ b/packages/desktop-notify/README.md
@@ -15,7 +15,7 @@ Desktop notifications for terminal applications. Focus-aware — suppresses noti
 
 As a pi extension:
 ```bash
-pi install pi-desktop-notify
+pi install npm:pi-desktop-notify
 ```
 
 As a library:

--- a/packages/safeguard/README.md
+++ b/packages/safeguard/README.md
@@ -5,7 +5,7 @@
 Security guardrail for [pi](https://pi.dev). Catches destructive commands, secret leaks, and overeager agents — without interrupting normal dev work.
 
 ```bash
-pi install pi-safeguard
+pi install npm:pi-safeguard
 ```
 
 No API keys, no config files. The judge model is auto-selected from your active provider.


### PR DESCRIPTION
- Document that new packages need a manual `npm publish` before OIDC trusted publishing works
- Add step-by-step for configuring trusted publishing on npmjs.com
- Add `npm:` prefix to all `pi install` commands across READMEs