### PR TITLE
chore: tidy package descriptions and keywords

### DIFF
--- a/packages/bash-trim/package.json
+++ b/packages/bash-trim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-bash-trim",
   "version": "1.0.2",
-  "description": "Smart bash output trimming for pi to fit LLM context budgets",
+  "description": "Smart bash output trimming for pi to fit LLM context budgets · from yapp",
   "author": "mgabor3141",
   "license": "MIT",
   "repository": {
@@ -10,8 +10,8 @@
   },
   "keywords": [
     "pi-package",
-    "output-trimming",
-    "token-budget"
+    "pi-extension",
+    "yapp"
   ],
   "type": "module",
   "main": "dist/index.js",

--- a/packages/budget-model/package.json
+++ b/packages/budget-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-budget-model",
   "version": "1.0.1",
-  "description": "Auto-select the cheapest available model for background tasks in pi",
+  "description": "Auto-select the cheapest available model for background tasks in pi · from yapp",
   "author": "mgabor3141",
   "license": "MIT",
   "repository": {
@@ -10,8 +10,8 @@
   },
   "keywords": [
     "pi-package",
-    "model-selection",
-    "cost-optimization"
+    "pi-library",
+    "yapp"
   ],
   "type": "module",
   "main": "dist/index.js",

--- a/packages/desktop-notify/package.json
+++ b/packages/desktop-notify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-desktop-notify",
   "version": "1.0.1",
-  "description": "Focus-aware desktop notifications for pi",
+  "description": "Focus-aware desktop notifications for pi · from yapp",
   "author": "mgabor3141",
   "license": "MIT",
   "repository": {
@@ -10,9 +10,8 @@
   },
   "keywords": [
     "pi-package",
-    "desktop-notifications",
-    "terminal",
-    "focus-tracking"
+    "pi-extension",
+    "yapp"
   ],
   "type": "module",
   "main": "dist/index.js",

--- a/packages/no-soft-cursor/package.json
+++ b/packages/no-soft-cursor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pi-no-soft-cursor",
 	"version": "1.0.0",
-	"description": "Remove the editor's reverse-video soft cursor — use only the terminal's native cursor",
+	"description": "Remove the editor's reverse-video soft cursor · from yapp",
 	"author": "mgabor3141",
 	"license": "MIT",
 	"repository": {
@@ -10,9 +10,8 @@
 	},
 	"keywords": [
 		"pi-package",
-		"editor",
-		"cursor",
-		"tui"
+		"pi-extension",
+		"yapp"
 	],
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/safeguard/package.json
+++ b/packages/safeguard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-safeguard",
   "version": "2.0.0",
-  "description": "LLM-as-judge guardrail for pi",
+  "description": "LLM-as-judge guardrail for pi · from yapp",
   "author": "mgabor3141",
   "license": "MIT",
   "repository": {
@@ -10,9 +10,8 @@
   },
   "keywords": [
     "pi-package",
-    "security",
-    "guardrail",
-    "llm-judge"
+    "pi-extension",
+    "yapp"
   ],
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
- add `· from yapp` to package descriptions
- simplify keywords to consistent yapp/pi package metadata
- use `pi-extension` for extensions and `pi-library` for the library