### PR TITLE
fix: make pi-no-soft-cursor work with editor overrides

### DIFF
--- a/.changeset/no-soft-cursor-editor-wrap.md
+++ b/.changeset/no-soft-cursor-editor-wrap.md
@@ -1,0 +1,5 @@
+---
+"pi-no-soft-cursor": patch
+---
+
+Make soft-cursor removal work even when other extensions replace pi's editor component.

--- a/packages/no-soft-cursor/README.md
+++ b/packages/no-soft-cursor/README.md
@@ -14,14 +14,15 @@ Pi's text editor renders a "soft cursor": the character under the cursor is show
 
 This extension:
 
-1. **Strips the soft cursor** — subclasses the editor and removes the last reverse-video span from each rendered line (the one the editor uses for the cursor block).
-2. **Forces the hardware cursor on** — pi has a "Show hardware cursor" setting that is off by default. This extension enables it unconditionally so the terminal's native cursor is always visible.
+1. **Strips the soft cursor** — patches editor rendering to remove the last reverse-video span from each rendered line (the one the editor uses for the cursor block).
+2. **Still works with editor-overriding extensions** — if another extension installs its own editor component, this package wraps that editor too instead of fighting to be the last `setEditorComponent()` call.
+3. **Forces the hardware cursor on** — pi has a "Show hardware cursor" setting that is off by default. This extension enables it unconditionally so the terminal's native cursor is always visible.
 
 > **Note:** With this extension active, pi's "Show hardware cursor" setting has no effect — the hardware cursor is always enabled.
 
 ## Setup
 
-After installing, **restart pi** for the extension to take effect. `/reload` alone is not sufficient due to a limitation in how pi manages the editor component during reload.
+After installing, reload pi with `/reload` or restart it.
 
 ## Configuration
 

--- a/packages/no-soft-cursor/src/index.ts
+++ b/packages/no-soft-cursor/src/index.ts
@@ -1,32 +1,89 @@
 /**
  * pi-no-soft-cursor — remove the editor's reverse-video "fake" cursor.
  *
- * The terminal's native (hardware) cursor is forced on so you still see
- * a blinking caret at the insertion point. Only the highlighted block that
- * the editor draws on top is removed.
- *
- * Note: with this extension active, pi's "Show hardware cursor" setting
- * has no effect — the hardware cursor is always enabled.
+ * This extension wraps editor rendering so it also works when other
+ * extensions install their own editor component (for example
+ * pi-powerline-footer), instead of relying on being the last extension to
+ * replace the editor.
  */
 
-import { CustomEditor, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { CustomEditor, type ExtensionAPI, InteractiveMode } from "@mariozechner/pi-coding-agent";
+import type { EditorComponent, EditorTheme, TUI } from "@mariozechner/pi-tui";
 
 import { stripSoftCursor } from "./strip.js";
 
-class NoCursorEditor extends CustomEditor {
-	constructor(...args: ConstructorParameters<typeof CustomEditor>) {
-		super(...args);
-		this.tui.setShowHardwareCursor(true);
-	}
+const RENDER_PATCHED = Symbol.for("pi-no-soft-cursor.render-patched");
+const FACTORY_PATCHED = Symbol.for("pi-no-soft-cursor.factory-patched");
+const UI_PATCHED = Symbol.for("pi-no-soft-cursor.ui-patched");
+const INTERACTIVE_MODE_PATCHED = Symbol.for("pi-no-soft-cursor.interactive-mode-patched");
 
-	render(width: number): string[] {
-		return super.render(width).map(stripSoftCursor);
-	}
+type Keybindings = ConstructorParameters<typeof CustomEditor>[2];
+type EditorFactory = (tui: TUI, theme: EditorTheme, keybindings: Keybindings) => EditorComponent;
+type HardwareCursorCapable = { tui?: { setShowHardwareCursor?(show: boolean): void } };
+type PatchedEditor = EditorComponent & HardwareCursorCapable & { [RENDER_PATCHED]?: boolean };
+type PatchableUI = {
+	[UI_PATCHED]?: boolean;
+	setEditorComponent(factory: EditorFactory | undefined): void;
+};
+
+function forceHardwareCursor(editor: unknown) {
+	(editor as HardwareCursorCapable | undefined)?.tui?.setShowHardwareCursor?.(true);
 }
+
+function patchEditorRender<T extends EditorComponent>(editor: T): T {
+	const patchedEditor = editor as PatchedEditor;
+	forceHardwareCursor(patchedEditor);
+	if (patchedEditor[RENDER_PATCHED]) return editor;
+
+	const originalRender = editor.render.bind(editor);
+	patchedEditor.render = ((width: number) => {
+		forceHardwareCursor(patchedEditor);
+		return originalRender(width).map(stripSoftCursor);
+	}) as typeof editor.render;
+	patchedEditor[RENDER_PATCHED] = true;
+	return editor;
+}
+
+function wrapEditorFactory(factory: EditorFactory): EditorFactory {
+	const patchedFactory = factory as EditorFactory & { [FACTORY_PATCHED]?: boolean };
+	if (patchedFactory[FACTORY_PATCHED]) return factory;
+
+	const wrappedFactory: EditorFactory = (tui, theme, keybindings) =>
+		patchEditorRender(factory(tui, theme, keybindings));
+	(wrappedFactory as EditorFactory & { [FACTORY_PATCHED]?: boolean })[FACTORY_PATCHED] = true;
+	return wrappedFactory;
+}
+
+function patchInteractiveMode() {
+	const prototype = InteractiveMode.prototype as unknown as {
+		[INTERACTIVE_MODE_PATCHED]?: boolean;
+		setCustomEditorComponent(factory: EditorFactory | undefined): void;
+	};
+	if (prototype[INTERACTIVE_MODE_PATCHED]) return;
+
+	const originalSetCustomEditorComponent = prototype.setCustomEditorComponent;
+	prototype.setCustomEditorComponent = function (factory: EditorFactory | undefined) {
+		return originalSetCustomEditorComponent.call(this, factory ? wrapEditorFactory(factory) : undefined);
+	};
+	prototype[INTERACTIVE_MODE_PATCHED] = true;
+}
+
+patchInteractiveMode();
 
 export default function (pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx) => {
 		if (!ctx.hasUI) return;
-		ctx.ui.setEditorComponent((tui, theme, kb) => new NoCursorEditor(tui, theme, kb));
+
+		const ui = ctx.ui as PatchableUI;
+		if (!ui[UI_PATCHED]) {
+			const originalSetEditorComponent = ui.setEditorComponent.bind(ui);
+			ui.setEditorComponent = (factory: EditorFactory | undefined) =>
+				originalSetEditorComponent(factory ? wrapEditorFactory(factory) : undefined);
+			ui[UI_PATCHED] = true;
+		}
+
+		ctx.ui.setEditorComponent((tui, theme, keybindings) =>
+			patchEditorRender(new CustomEditor(tui, theme, keybindings)),
+		);
 	});
 }


### PR DESCRIPTION
## Summary
- wrap the default editor on session start so soft-cursor stripping still works with no other extensions installed
- wrap later `setEditorComponent()` calls so extensions like powerline footer still get soft-cursor stripping
- update the README and include a changeset

<img width="125" height="142" alt="image" src="https://github.com/user-attachments/assets/8503a3ea-e6a3-4754-a278-82a574e378d2" />

## Testing
- yarn workspace pi-no-soft-cursor build
- yarn test
- yarn lint