### PR TITLE
fix(ci): trigger checks for version package PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       id-token: write
@@ -27,9 +28,16 @@ jobs:
 
       - run: yarn build
 
-      - uses: changesets/action@v1
+      - id: changesets
+        uses: changesets/action@v1
         with:
           version: yarn ci:version
           publish: yarn ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger CI for version PR branch
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ci.yml --ref "changeset-release/${{ github.ref_name }}"


### PR DESCRIPTION
## Summary
- add manual dispatch support to the CI workflow
- have the release workflow trigger CI on the `changeset-release/<base>` branch after Changesets updates the version PR
- grant the release workflow the permissions needed to dispatch that run

## Testing
- yarn test
- yarn lint