### PR TITLE
feat: add pi-enclave VM sandbox with secret protection

### DIFF
--- a/.changeset/add-pi-enclave.md
+++ b/.changeset/add-pi-enclave.md
@@ -1,0 +1,19 @@
+---
+"pi-enclave": minor
+---
+
+Initial release of pi-enclave: VM-isolated enclave with automatic secret protection.
+
+- All tools (bash, read, write, edit) execute inside a Gondolin micro-VM
+- Modular drop-in config files (`pi-enclave.d/`): git, jj, GitHub ship by default
+- Generic `[env]` section: inject host values (static, command, env var) into the VM
+- `setup` scripts per drop-in: raw shell, run after package install
+- Secrets with HTTP proxy injection (never enter the VM)
+- `[[git-credentials]]` for explicit git auth over HTTPS
+- Per-host HTTP policies with allow/deny/prompt for method+path patterns
+- GraphQL-aware policy: parses request bodies, checks actual field names (not spoofable operation names)
+- `[[mounts]]` for additional directories (e.g. jj workspace parent repos)
+- Cascading config: global + drop-ins + project
+- Packages accumulate additively across all config layers
+- `/enclave init`, `/enclave on|off`, `/enclave add` with interactive search
+- Eager VM startup on session start/resume

--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 ***y**et **a**nother **p**i **p**ack*
 
-Utilities for running [pi](https://pi.dev) agents with less babysitting: auto-review risky shell commands, compress noisy terminal output before it bloats context, and get notified when unattended work finishes.
+Utilities for running [pi](https://pi.dev) agents with less babysitting: sandbox tools in a VM, auto-review risky shell commands, compress noisy terminal output before it bloats context, and get notified when unattended work finishes.
 
 ## The Pack
 
 Install the extensions together, or pick only the ones you want. Defaults are tuned for good behavior out of the box.
 
 ```bash
-pi install npm:pi-safeguard npm:pi-bash-trim npm:pi-desktop-notify npm:pi-no-soft-cursor
+pi install npm:pi-enclave npm:pi-safeguard npm:pi-bash-trim npm:pi-desktop-notify npm:pi-no-soft-cursor
 ```
+
+### [pi-enclave](packages/enclave/)
+
+VM-isolated sandbox. All agent tools (bash, read, write, edit) execute inside a Gondolin micro-VM (QEMU/aarch64 Alpine Linux). Secrets are resolved on the host and injected via HTTP proxy; the VM never sees real credential values. Per-host policies control what the agent can do: GraphQL mutations are checked at the AST level, git pushes require approval, reads pass through. Configuration is modular: drop-in files in `pi-enclave.d/` add tool support (git, jj, GitHub) with their own packages, setup scripts, and policies. Delete a file to disable that integration.
 
 ### [pi-safeguard](packages/safeguard/)
 

--- a/packages/enclave/README.md
+++ b/packages/enclave/README.md
@@ -1,0 +1,161 @@
+# pi-enclave
+
+> From [yapp](https://github.com/mgabor3141/yapp) · yet another pi pack
+
+VM-isolated enclave for [pi](https://pi.dev). Runs all tools inside a [Gondolin](https://github.com/earendil-works/gondolin) micro-VM so secrets never enter the agent's execution environment.
+
+```bash
+pi install npm:pi-enclave
+```
+
+Requires QEMU: `brew install qemu` (macOS) or `sudo apt install qemu-system-aarch64` (Linux).
+
+## How it works
+
+pi-enclave starts an Alpine Linux micro-VM (QEMU/aarch64) and redirects all tool execution into it. Your workspace is mounted read-write at the same path inside the VM, so tools see identical paths on host and guest. File changes are bidirectional.
+
+The core security property: **secrets never enter the VM**. Secrets configured in your TOML config (like `gh auth token`) are resolved on the host, and their values are replaced with random placeholders inside the VM. Gondolin's HTTP proxy substitutes real values on the wire, only for requests to configured hosts.
+
+```
+┌──────────────────────────────────────────────────┐
+│  Gondolin VM (Alpine Linux)                      │
+│                                                  │
+│  /home/user/project ← bidirectional mount        │
+│  GH_TOKEN = "GONDOLIN_SECRET_a8f3..." (placeholder)│
+│  All pi tools execute here                       │
+└────────────────────┬─────────────────────────────┘
+                     │ HTTP
+                     ▼
+┌──────────────────────────────────────────────────┐
+│  HTTP proxy (host-side)                          │
+│  placeholder → real value (only for allowed hosts)│
+└──────────────────────────────────────────────────┘
+```
+
+## Getting started
+
+```
+/enclave init
+```
+
+This creates:
+- `~/.pi/agent/extensions/pi-enclave.toml` — global config (env vars, base packages)
+- `~/.pi/agent/extensions/pi-enclave.d/` — drop-in files (git, jj, GitHub)
+- `.pi/enclave.toml` — project config with `enabled = true`
+
+Once enabled, all tools (bash, read, write, edit) execute inside the VM automatically.
+
+## Drop-in files
+
+Service integrations live in `pi-enclave.d/` as self-contained TOML files. Each can contribute packages, setup scripts, secrets, and host policies. Delete a file to disable that integration.
+
+```
+~/.pi/agent/extensions/
+├── pi-enclave.toml              # base config: curl, jq, env vars
+└── pi-enclave.d/
+    ├── git.toml                 # git + user identity
+    ├── github.toml              # github-cli + secrets + policies
+    └── jj.toml                  # jujutsu + user identity
+```
+
+Example drop-in (`git.toml`):
+
+```toml
+packages = ["git"]
+setup = """
+git config --global safe.directory '*'
+git config --global user.name "$USER_NAME"
+git config --global user.email "$USER_EMAIL"
+"""
+```
+
+`USER_NAME` and `USER_EMAIL` are defined in the main config as env vars resolved from the host:
+
+```toml
+[env]
+USER_NAME = { command = "git config --global user.name" }
+USER_EMAIL = { command = "git config --global user.email" }
+```
+
+## Configuration
+
+### Env vars
+
+Non-secret values available in the VM and setup scripts. Three source types:
+
+```toml
+[env]
+EDITOR = "vim"                                     # static
+USER_NAME = { command = "git config user.name" }   # host command
+GOPATH = { env = "GOPATH" }                        # host env var
+```
+
+### Secrets
+
+Like env vars, but values never enter the VM. The HTTP proxy injects them on the wire.
+
+```toml
+[secrets.GH_TOKEN]
+command = "gh auth token"
+hosts = ["api.github.com", "github.com", "*.githubusercontent.com"]
+```
+
+### Git credentials
+
+Configures git credential helpers using secret placeholders:
+
+```toml
+[[git-credentials]]
+host = "github.com"
+username = "x-access-token"
+secret = "GH_TOKEN"
+```
+
+### Host policies
+
+Access control per host. `unmatched` determines what happens to requests that don't match any allow/deny rule.
+
+```toml
+[hosts."api.github.com"]
+unmatched = "prompt"
+allow.GET = ["/**"]
+
+[hosts."api.github.com".graphql]
+endpoint = "/graphql"
+allow.query = ["*"]
+allow.mutation = ["createPullRequest", "createIssue", "addComment"]
+```
+
+GraphQL policy parses the request body and checks actual field names (not the spoofable operation name).
+
+### Mounts
+
+Additional directories to mount in the VM (e.g. for jj workspaces):
+
+```toml
+[[mounts]]
+path = "~/dev/myproject/.jj"
+```
+
+### Config layering
+
+Two locations: global (`~/.pi/agent/extensions/pi-enclave.toml` + drop-ins) and project (`.pi/enclave.toml`). Project overrides global. Packages accumulate across all layers; secrets, hosts, and env merge by key (later wins).
+
+```toml
+# .pi/enclave.toml — allow all GitHub operations in this project
+enabled = true
+
+[hosts."api.github.com"]
+unmatched = "allow"
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/enclave` or `/enclave status` | Show VM state, packages, secrets |
+| `/enclave init` | Create project and global config files, enable enclave |
+| `/enclave on` | Enable VM isolation for this session |
+| `/enclave off` | Disable VM isolation for this session (shuts down VM) |
+| `/enclave restart` | Restart VM on next tool use |
+| `/enclave add <package>` | Search for and install an Alpine package |

--- a/packages/enclave/package.json
+++ b/packages/enclave/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "pi-enclave",
+  "version": "0.0.1",
+  "description": "VM-isolated sandbox for pi with automatic secret protection · from yapp",
+  "author": "mgabor3141",
+  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/mgabor3141/yapp.git",
+    "directory": "packages/enclave"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "yapp"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "templates",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "dependencies": {
+    "@earendil-works/gondolin": "^0.6.0",
+    "graphql": "^16.13.1",
+    "smol-toml": "^1.6.0",
+    "valibot": "^1.2.0"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@types/node": "^25.3.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/enclave/src/config.ts
+++ b/packages/enclave/src/config.ts
@@ -1,0 +1,470 @@
+/**
+ * Configuration schema and resolution for pi-enclave.
+ *
+ * Config is TOML, loaded from cascading `.pi/enclave.toml` files on the host.
+ * The agent never influences config resolution.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseTOML } from "smol-toml";
+import * as v from "valibot";
+
+// ---------------------------------------------------------------------------
+// Template directory resolution
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Resolve a path within the templates/ directory. Works from both src/ and dist/. */
+function templatePath(...segments: string[]): string {
+	// From dist/: ../templates/  From src/: ../templates/
+	return join(__dirname, "..", "templates", ...segments);
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/** Secret definition: how to obtain a credential and which hosts receive it. */
+const SecretDef = v.union([
+	// Disable a secret inherited from a parent config
+	v.literal(false),
+	// Command source: run a host command, use stdout as value
+	v.object({
+		command: v.string(),
+		hosts: v.array(v.string()),
+	}),
+	// Env source: read from a host environment variable
+	v.object({
+		env: v.string(),
+		hosts: v.array(v.string()),
+	}),
+]);
+export type SecretDef = v.InferOutput<typeof SecretDef>;
+
+/** Environment variable definition: static value, host command, or host env var. */
+const EnvDef = v.union([
+	// Static value
+	v.string(),
+	// From a host command
+	v.object({ command: v.string() }),
+	// From a host environment variable
+	v.object({ env: v.string() }),
+]);
+export type EnvDef = v.InferOutput<typeof EnvDef>;
+
+const UnmatchedPolicy = v.picklist(["prompt", "deny", "allow"]);
+export type UnmatchedPolicy = v.InferOutput<typeof UnmatchedPolicy>;
+
+/** GraphQL endpoint policy. */
+const GraphQLPolicy = v.object({
+	endpoint: v.string(),
+	allow: v.object({
+		query: v.optional(v.array(v.string()), []),
+		mutation: v.optional(v.array(v.string()), []),
+	}),
+	unmatched: v.optional(UnmatchedPolicy),
+});
+export type GraphQLPolicy = v.InferOutput<typeof GraphQLPolicy>;
+
+/** Per-host allow rules: METHOD -> path patterns. */
+const HostAllow = v.record(v.string(), v.array(v.string()));
+
+/** Per-host policy. Key = quoted hostname in TOML. */
+const HostDef = v.object({
+	/** Which secret to inject for requests to this host (references a key in [secrets]) */
+	secret: v.optional(v.string()),
+	/** Allowed HTTP method + path patterns */
+	allow: v.optional(HostAllow, {}),
+	/** Paths that are always denied (overrides allow) */
+	deny: v.optional(v.array(v.string()), []),
+	/** What happens for requests that don't match allow or deny */
+	unmatched: v.optional(UnmatchedPolicy, "allow"),
+	/** GraphQL-specific policy for a specific endpoint */
+	graphql: v.optional(GraphQLPolicy),
+});
+export type HostDef = v.InferOutput<typeof HostDef>;
+
+/** Additional directory to mount in the VM. */
+const MountDef = v.object({
+	path: v.string(),
+	readonly: v.optional(v.boolean(), false),
+});
+
+/** Git credential helper configuration. */
+const GitCredentialDef = v.object({
+	host: v.string(),
+	username: v.string(),
+	secret: v.string(),
+});
+export type GitCredentialDef = v.InferOutput<typeof GitCredentialDef>;
+
+/** Top-level enclave config file schema. */
+export const EnclaveFileConfig = v.object({
+	enabled: v.optional(v.boolean()),
+	packages: v.optional(v.array(v.string())),
+	mounts: v.optional(v.array(MountDef), []),
+	env: v.optional(v.record(v.string(), EnvDef), {}),
+	secrets: v.optional(v.record(v.string(), SecretDef), {}),
+	"git-credentials": v.optional(v.array(GitCredentialDef), []),
+	hosts: v.optional(v.record(v.string(), HostDef), {}),
+	setup: v.optional(v.string()),
+});
+export type EnclaveFileConfig = v.InferOutput<typeof EnclaveFileConfig>;
+
+// ---------------------------------------------------------------------------
+// Resolved config (after merging all layers)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedSecret {
+	name: string;
+	value: string;
+	hosts: string[];
+}
+
+export interface ResolvedGraphQLPolicy {
+	endpoint: string;
+	allow: { query: string[]; mutation: string[] };
+	unmatched: UnmatchedPolicy;
+}
+
+export interface ResolvedHostPolicy {
+	hostname: string;
+	allows: Map<string, string[]>; // METHOD -> path patterns
+	deny: string[];
+	unmatched: UnmatchedPolicy;
+	graphql?: ResolvedGraphQLPolicy;
+}
+
+// ---------------------------------------------------------------------------
+// Default packages
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PACKAGES = ["git", "curl", "jq"];
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+function readTomlFile(path: string): EnclaveFileConfig | undefined {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw new Error(`pi-enclave: failed to read config at ${path}: ${(err as Error).message}`);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parseTOML(raw);
+	} catch (err) {
+		throw new Error(`pi-enclave: invalid TOML at ${path}: ${(err as Error).message}`);
+	}
+
+	try {
+		return v.parse(EnclaveFileConfig, parsed);
+	} catch (err) {
+		throw new Error(`pi-enclave: invalid config at ${path}: ${(err as Error).message}`);
+	}
+}
+
+/**
+ * Collect config files: global config + drop-ins, then project config.
+ * Two locations, predictable merge order.
+ */
+export function collectConfigFiles(cwd: string): { path: string; config: EnclaveFileConfig }[] {
+	const layers: { path: string; config: EnclaveFileConfig }[] = [];
+
+	// Global config
+	const globalPath = globalConfigPath();
+	const globalConfig = readTomlFile(globalPath);
+	if (globalConfig) {
+		layers.push({ path: globalPath, config: globalConfig });
+	}
+
+	// Drop-in configs from pi-enclave.d/ (alphabetical order)
+	const dropInDir = globalDropInDir();
+	if (existsSync(dropInDir)) {
+		const files = readdirSync(dropInDir)
+			.filter((f) => f.endsWith(".toml"))
+			.sort();
+		for (const file of files) {
+			const filePath = join(dropInDir, file);
+			const config = readTomlFile(filePath);
+			if (config) {
+				layers.push({ path: filePath, config });
+			}
+		}
+	}
+
+	// Project config
+	const projectPath = join(resolve(cwd), ".pi", "enclave.toml");
+	const projectConfig = readTomlFile(projectPath);
+	if (projectConfig) {
+		layers.push({ path: projectPath, config: projectConfig });
+	}
+
+	return layers;
+}
+
+/**
+ * Merge config layers. Later layers override earlier ones.
+ * Secrets and hosts are merged by key (later wins).
+ * Packages: last explicit `packages` array wins entirely.
+ */
+export function mergeConfigs(layers: EnclaveFileConfig[]): EnclaveFileConfig {
+	const merged: EnclaveFileConfig = {
+		enabled: undefined,
+		packages: [],
+		mounts: [],
+		env: {},
+		secrets: {},
+		"git-credentials": [],
+		hosts: {},
+	};
+
+	// Track mounts and git-credentials by key to deduplicate (later layer wins)
+	const mountsByPath = new Map<string, { path: string; readonly: boolean }>();
+	const gitCredsByHost = new Map<string, GitCredentialDef>();
+	// Collect setup scripts in order (each file's script runs sequentially)
+	const setupScripts: string[] = [];
+
+	for (const layer of layers) {
+		if (layer.enabled !== undefined) {
+			merged.enabled = layer.enabled;
+		}
+		if (layer.packages) {
+			for (const pkg of layer.packages) {
+				if (!merged.packages!.includes(pkg)) {
+					merged.packages!.push(pkg);
+				}
+			}
+		}
+		if (layer.mounts) {
+			for (const mount of layer.mounts) {
+				mountsByPath.set(mount.path, mount);
+			}
+		}
+		if (layer.env) {
+			for (const [key, val] of Object.entries(layer.env)) {
+				merged.env![key] = val;
+			}
+		}
+		if (layer.secrets) {
+			for (const [key, val] of Object.entries(layer.secrets)) {
+				merged.secrets![key] = val;
+			}
+		}
+		if (layer["git-credentials"]) {
+			for (const cred of layer["git-credentials"]) {
+				gitCredsByHost.set(cred.host, cred);
+			}
+		}
+		if (layer.hosts) {
+			for (const [key, val] of Object.entries(layer.hosts)) {
+				merged.hosts![key] = val;
+			}
+		}
+		if (layer.setup) {
+			setupScripts.push(layer.setup);
+		}
+	}
+
+	merged.mounts = [...mountsByPath.values()];
+	merged["git-credentials"] = [...gitCredsByHost.values()];
+	// Concatenate all setup scripts (each separated by newline)
+	if (setupScripts.length > 0) {
+		merged.setup = setupScripts.join("\n");
+	}
+
+	return merged;
+}
+
+/**
+ * Parse a merged config into resolved host policies.
+ * Only hosts with actual policy rules (allow, deny, unmatched != default, or graphql)
+ * are included.
+ */
+export function resolveHostPolicies(config: EnclaveFileConfig): Map<string, ResolvedHostPolicy> {
+	const result = new Map<string, ResolvedHostPolicy>();
+
+	for (const [hostname, hostDef] of Object.entries(config.hosts ?? {})) {
+		const allows = new Map<string, string[]>();
+		for (const [method, patterns] of Object.entries(hostDef.allow ?? {})) {
+			allows.set(method.toUpperCase(), patterns);
+		}
+
+		const hostUnmatched = hostDef.unmatched ?? "allow";
+
+		let graphql: ResolvedGraphQLPolicy | undefined;
+		if (hostDef.graphql) {
+			graphql = {
+				endpoint: hostDef.graphql.endpoint,
+				allow: {
+					query: hostDef.graphql.allow.query ?? [],
+					mutation: hostDef.graphql.allow.mutation ?? [],
+				},
+				// GraphQL inherits host unmatched if not set
+				unmatched: hostDef.graphql.unmatched ?? hostUnmatched,
+			};
+		}
+
+		result.set(hostname, {
+			hostname,
+			allows,
+			deny: hostDef.deny ?? [],
+			unmatched: hostUnmatched,
+			graphql,
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Load the fully resolved config for a given cwd.
+ * Does NOT resolve secrets (that requires running commands).
+ */
+export function loadConfig(cwd: string): {
+	merged: EnclaveFileConfig;
+	policies: Map<string, ResolvedHostPolicy>;
+	hasGlobalConfig: boolean;
+	hasProjectConfig: boolean;
+	dropIns: string[];
+} {
+	const layers = collectConfigFiles(cwd);
+	const merged = mergeConfigs(layers.map((l) => l.config));
+	const policies = resolveHostPolicies(merged);
+
+	const hasGlobalConfig = layers.some((l) => l.path === globalConfigPath());
+	const projectPath = join(cwd, ".pi", "enclave.toml");
+	const hasProjectConfig = layers.some((l) => l.path === projectPath);
+
+	// Collect drop-in file names (without extension, for display)
+	const dropInPrefix = globalDropInDir();
+	const dropIns = layers.filter((l) => l.path.startsWith(dropInPrefix)).map((l) => basename(l.path, ".toml"));
+
+	// Expand ~ in mount paths
+	if (merged.mounts) {
+		const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+		merged.mounts = merged.mounts.map((m) => ({
+			...m,
+			path: m.path.startsWith("~/") ? join(home, m.path.slice(2)) : m.path === "~" ? home : m.path,
+		}));
+	}
+
+	return { merged, policies, hasGlobalConfig, hasProjectConfig, dropIns };
+}
+
+// ---------------------------------------------------------------------------
+// Config paths and modification
+// ---------------------------------------------------------------------------
+
+export function globalConfigPath(): string {
+	return join(process.env.HOME ?? process.env.USERPROFILE ?? "~", ".pi", "agent", "extensions", "pi-enclave.toml");
+}
+
+export function globalDropInDir(): string {
+	return join(process.env.HOME ?? process.env.USERPROFILE ?? "~", ".pi", "agent", "extensions", "pi-enclave.d");
+}
+
+export function projectConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "enclave.toml");
+}
+
+/** Replace the home directory prefix with ~ for display. */
+export function tildify(p: string): string {
+	const home = process.env.HOME ?? process.env.USERPROFILE;
+	if (!home) return p;
+	if (p === home) return "~";
+	if (p.startsWith(`${home}/`)) return `~${p.slice(home.length)}`;
+	return p;
+}
+
+// ---------------------------------------------------------------------------
+// Config file creation (copies from templates/)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the global config and drop-in directory if they don't exist.
+ * Copies from templates/. Returns list of created files for display.
+ */
+export function ensureGlobalConfig(): string[] {
+	const created: string[] = [];
+
+	const configPath = globalConfigPath();
+	if (!existsSync(configPath)) {
+		mkdirSync(dirname(configPath), { recursive: true });
+		cpSync(templatePath("pi-enclave.toml"), configPath);
+		created.push(configPath);
+	}
+
+	const dropInDir = globalDropInDir();
+	mkdirSync(dropInDir, { recursive: true });
+
+	// Copy all template drop-in files that don't already exist
+	const templateDropInDir = templatePath("pi-enclave.d");
+	for (const file of readdirSync(templateDropInDir).filter((f) => f.endsWith(".toml"))) {
+		const dest = join(dropInDir, file);
+		if (!existsSync(dest)) {
+			cpSync(join(templateDropInDir, file), dest);
+			created.push(dest);
+		}
+	}
+
+	return created;
+}
+
+/**
+ * Create the project config with enabled = true.
+ * Returns true if the file was created.
+ */
+export function initProjectConfig(cwd: string): boolean {
+	const configPath = projectConfigPath(cwd);
+	if (existsSync(configPath)) return false;
+	const dir = dirname(configPath);
+	mkdirSync(dir, { recursive: true });
+	cpSync(templatePath("project.toml"), configPath);
+	return true;
+}
+
+/**
+ * Add a package to a config file. Creates the file if needed.
+ */
+export function addPackageToConfig(cwd: string, pkg: string, target: "project" | "global"): void {
+	const configPath = target === "global" ? globalConfigPath() : projectConfigPath(cwd);
+
+	let existing: Partial<EnclaveFileConfig> = {};
+	try {
+		const content = readFileSync(configPath, "utf-8");
+		const parsed = parseTOML(content);
+		const result = v.safeParse(EnclaveFileConfig, parsed);
+		if (result.success) existing = result.output;
+	} catch {
+		// File doesn't exist or is invalid, start fresh
+	}
+
+	const packages = existing.packages ?? [...DEFAULT_PACKAGES];
+	if (!packages.includes(pkg)) {
+		packages.push(pkg);
+	}
+
+	const dir = dirname(configPath);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+	const packagesLine = `packages = [${packages.map((p) => `"${p}"`).join(", ")}]`;
+
+	if (existsSync(configPath)) {
+		const raw = readFileSync(configPath, "utf-8");
+		if (raw.match(/^packages\s*=/m)) {
+			writeFileSync(configPath, raw.replace(/^packages\s*=.*$/m, packagesLine), "utf-8");
+		} else {
+			writeFileSync(configPath, `${packagesLine}\n${raw}`, "utf-8");
+		}
+	} else {
+		writeFileSync(configPath, `${packagesLine}\n`, "utf-8");
+	}
+}

--- a/packages/enclave/src/graphql.ts
+++ b/packages/enclave/src/graphql.ts
@@ -1,0 +1,112 @@
+/**
+ * GraphQL policy enforcement.
+ *
+ * Parses GraphQL request bodies to extract operation types and
+ * top-level field names, then checks them against a configured
+ * allow list.
+ *
+ * This provides defense-in-depth: the operation name is client-controlled
+ * and can't be trusted, but the actual field names in the selection set
+ * reveal what the mutation really does.
+ */
+
+import { type DocumentNode, type OperationDefinitionNode, parse } from "graphql";
+
+export interface GraphQLOperation {
+	/** "query" | "mutation" | "subscription" */
+	type: string;
+	/** Operation name (may be undefined for anonymous operations) */
+	name: string | undefined;
+	/** Top-level field names in the selection set */
+	fields: string[];
+}
+
+/**
+ * Parse a GraphQL request body and extract operations.
+ * Returns undefined if the body can't be parsed.
+ */
+export function parseGraphQLBody(body: string): GraphQLOperation[] | undefined {
+	let json: { query?: string };
+	try {
+		json = JSON.parse(body);
+	} catch {
+		return undefined;
+	}
+
+	const query = json.query;
+	if (typeof query !== "string") return undefined;
+
+	let doc: DocumentNode;
+	try {
+		doc = parse(query);
+	} catch {
+		return undefined;
+	}
+
+	const operations: GraphQLOperation[] = [];
+	for (const def of doc.definitions) {
+		if (def.kind !== "OperationDefinition") continue;
+		const opDef = def as OperationDefinitionNode;
+		const fields: string[] = [];
+		for (const sel of opDef.selectionSet.selections) {
+			if (sel.kind === "Field") {
+				fields.push(sel.name.value);
+			}
+		}
+		operations.push({
+			type: opDef.operation,
+			name: opDef.name?.value,
+			fields,
+		});
+	}
+
+	return operations;
+}
+
+/**
+ * Check whether a GraphQL request should be allowed based on the policy.
+ *
+ * The allow object maps operation types to field patterns:
+ *   { query: ["*"], mutation: ["createPullRequest", "create*"] }
+ *
+ * Returns allowed: true if all operations match, or details about denied fields.
+ */
+export function checkGraphQLPolicy(
+	operations: GraphQLOperation[],
+	allow: { query: string[]; mutation: string[] },
+): { allowed: true } | { allowed: false; denied: GraphQLOperation[]; deniedFields: string[] } {
+	const denied: GraphQLOperation[] = [];
+	const deniedFields: string[] = [];
+
+	for (const op of operations) {
+		const patterns = op.type === "query" ? allow.query : op.type === "mutation" ? allow.mutation : undefined;
+
+		if (!patterns || patterns.length === 0) {
+			// No rules for this operation type
+			denied.push(op);
+			deniedFields.push(...op.fields);
+			continue;
+		}
+
+		// Check if all fields match at least one pattern
+		const unmatchedFields = op.fields.filter((field) => !patterns.some((p) => globMatch(p, field)));
+
+		if (unmatchedFields.length > 0) {
+			denied.push(op);
+			deniedFields.push(...unmatchedFields);
+		}
+	}
+
+	if (denied.length === 0) return { allowed: true };
+	return { allowed: false, denied, deniedFields };
+}
+
+/**
+ * Simple glob match: * matches any sequence of characters.
+ */
+function globMatch(pattern: string, value: string): boolean {
+	if (pattern === "*") return true;
+	// Convert glob to regex: escape regex chars, replace * with .*
+	const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+	return new RegExp(`^${escaped}$`, "i").test(value);
+}

--- a/packages/enclave/src/index.ts
+++ b/packages/enclave/src/index.ts
@@ -1,0 +1,507 @@
+/**
+ * pi-enclave
+ *
+ * VM-isolated enclave for pi with automatic secret protection.
+ * All pi tools (bash, read, write, edit) execute inside a Gondolin micro-VM.
+ * Secrets never enter the VM; the HTTP proxy injects them on the wire.
+ *
+ * See README.md for architecture and configuration details.
+ */
+
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createBashTool, createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
+
+import {
+	DEFAULT_PACKAGES,
+	addPackageToConfig,
+	ensureGlobalConfig,
+	globalConfigPath,
+	globalDropInDir,
+	initProjectConfig,
+	loadConfig,
+	projectConfigPath,
+	tildify,
+} from "./config.js";
+import type { ResolvedSecret } from "./config.js";
+import { resolveEnv, resolveSecrets } from "./secrets.js";
+import { createVmBashOps, createVmEditOps, createVmReadOps, createVmWriteOps, shQuote } from "./tools.js";
+import { EnclaveVM, checkQemuAvailable } from "./vm.js";
+
+// ---------------------------------------------------------------------------
+// Package name extraction: "ripgrep-14.1.1-r0" -> "ripgrep"
+// ---------------------------------------------------------------------------
+
+function extractPkgName(versionedName: string): string {
+	const match = versionedName.match(/^(.+?)-\d/);
+	return match ? match[1] : versionedName;
+}
+
+// ---------------------------------------------------------------------------
+// /enclave add: search, confirm, install, persist
+// ---------------------------------------------------------------------------
+
+async function handleAddPackage(
+	query: string,
+	enclaveVm: EnclaveVM,
+	cwd: string,
+	ctx: {
+		ui: {
+			notify: (message: string, level?: "info" | "warning" | "error") => void;
+			confirm: (title: string, message: string) => Promise<boolean>;
+			select: (title: string, options: string[]) => Promise<string | undefined>;
+		};
+	},
+): Promise<void> {
+	const vm = enclaveVm.rawVm;
+
+	// Shell-safe query for apk commands
+	const q = shQuote(query);
+
+	// Try exact match (apk add during VM startup populates the index cache)
+	let exactResult = await vm.exec(`apk search --exact ${q}`);
+
+	// If the cache is missing, try refreshing it
+	if (!exactResult.ok && exactResult.stderr.includes("No such file")) {
+		await vm.exec("apk update --quiet");
+		exactResult = await vm.exec(`apk search --exact ${q}`);
+	}
+
+	let targetPkg: string | undefined;
+
+	if (exactResult.ok && exactResult.stdout.trim()) {
+		// Exact package exists, show info and confirm
+		const infoResult = await vm.exec(`apk info ${q}`);
+		const info = infoResult.ok ? infoResult.stdout.trim() : `Package: ${query}`;
+		const ok = await ctx.ui.confirm(`🧊 Install ${query}?`, info);
+		if (ok) targetPkg = query;
+	} else {
+		// Substring search on package names
+		const searchResult = await vm.exec(`apk search ${q}`);
+		const rawLines = searchResult.ok ? searchResult.stdout.trim().split("\n").filter(Boolean) : [];
+
+		// Filter out -doc, -dev, -completion, -pyc subpackages
+		const filtered = rawLines.filter(
+			(l) => !/-(?:doc|dev|lang|dbg|bash-completion|zsh-completion|fish-completion|pyc)-\d/.test(l),
+		);
+
+		if (filtered.length === 0) {
+			ctx.ui.notify(`No packages found for "${query}".`, "warning");
+			return;
+		}
+
+		// Get descriptions for each match
+		const pkgNames = filtered.slice(0, 10).map(extractPkgName);
+		const uniqueNames = [...new Set(pkgNames)];
+
+		const options: string[] = [];
+		for (const name of uniqueNames) {
+			const descResult = await vm.exec(`apk info --description ${shQuote(name)}`);
+			const desc = descResult.ok
+				? descResult.stdout
+						.trim()
+						.split("\n")
+						.find((l) => !l.includes("description:") && l.trim())
+				: undefined;
+			options.push(desc ? `${name} \u2014 ${desc.trim()}` : name);
+		}
+		options.push("Cancel");
+
+		const choice = await ctx.ui.select(`🧊 No exact match for "${query}". Select a package:`, options);
+		if (!choice || choice === "Cancel") return;
+
+		targetPkg = choice.split(" \u2014 ")[0];
+	}
+
+	if (!targetPkg) return;
+
+	// Install
+	const installResult = await enclaveVm.installPackage(targetPkg);
+	if (!installResult.ok) {
+		ctx.ui.notify(`\u274C Failed to install ${targetPkg}: ${installResult.stderr.slice(0, 200)}`, "error");
+		return;
+	}
+
+	// Offer to persist
+	const saveChoice = await ctx.ui.select(`\u2705 Installed ${targetPkg}. Save to config?`, [
+		"Save to project (.pi/enclave.toml)",
+		`Save to global (${tildify(globalConfigPath())})`,
+		"Don't save (this session only)",
+	]);
+
+	if (saveChoice === "Save to project (.pi/enclave.toml)") {
+		addPackageToConfig(cwd, targetPkg, "project");
+		ctx.ui.notify(`🧊 Added ${targetPkg} to .pi/enclave.toml`);
+	} else if (saveChoice?.startsWith("Save to global")) {
+		addPackageToConfig(cwd, targetPkg, "global");
+		ctx.ui.notify(`🧊 Added ${targetPkg} to ${tildify(globalConfigPath())}`);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+/** Session entry type for recording per-session on/off toggle. */
+const SESSION_ENTRY_TYPE = "enclave:active";
+
+export default function (pi: ExtensionAPI) {
+	// -----------------------------------------------------------------------
+	// Pre-flight: check QEMU
+	// -----------------------------------------------------------------------
+	const qemu = checkQemuAvailable();
+	if (!qemu.available) {
+		pi.on("session_start", (_event, ctx) => {
+			ctx.ui.notify(qemu.message!, "error");
+		});
+		return;
+	}
+
+	// -----------------------------------------------------------------------
+	// Ensure global config template exists
+	// -----------------------------------------------------------------------
+	ensureGlobalConfig();
+
+	// -----------------------------------------------------------------------
+	// Load config and secrets
+	// -----------------------------------------------------------------------
+	const localCwd = process.cwd();
+	const { merged, policies, hasGlobalConfig, hasProjectConfig, dropIns } = loadConfig(localCwd);
+	const packages = merged.packages?.length ? merged.packages : DEFAULT_PACKAGES;
+	const extraMounts = merged.mounts ?? [];
+	const gitCredentials = merged["git-credentials"] ?? [];
+	// Network allowlist is derived from secret hosts (Gondolin builds the allowlist)
+	const allowedHosts: string[] | undefined = undefined;
+
+	// Resolve env vars from config (non-secret, injected as real VM env vars)
+	const extraEnv = resolveEnv(merged.env);
+	const setupScript = merged.setup;
+
+	let secrets: ResolvedSecret[];
+	try {
+		secrets = resolveSecrets(merged.secrets);
+	} catch (err) {
+		pi.on("session_start", (_event, ctx) => {
+			ctx.ui.notify(`pi-enclave: failed to resolve secrets: ${(err as Error).message}`, "error");
+		});
+		return;
+	}
+
+	// -----------------------------------------------------------------------
+	// Activation state
+	// -----------------------------------------------------------------------
+	// enabled from config (undefined = not configured)
+	const configEnabled = merged.enabled;
+	// session override (set by /enclave on|off, or from session log on resume)
+	let sessionOverride: boolean | undefined;
+
+	function isActive(): boolean {
+		if (sessionOverride !== undefined) return sessionOverride;
+		return configEnabled === true;
+	}
+
+	function getSessionActivation(ctx: ExtensionContext): boolean | undefined {
+		const entries = ctx.sessionManager.getEntries();
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const entry = entries[i];
+			if (entry.type === "custom" && entry.customType === SESSION_ENTRY_TYPE) {
+				return entry.data as boolean;
+			}
+		}
+		return undefined;
+	}
+
+	// -----------------------------------------------------------------------
+	// VM lifecycle
+	// -----------------------------------------------------------------------
+	let enclaveVm: EnclaveVM | undefined;
+	let vmStarting: Promise<EnclaveVM> | undefined;
+
+	async function shutdownVm() {
+		if (enclaveVm) {
+			await enclaveVm.close();
+			enclaveVm = undefined;
+		}
+		vmStarting = undefined;
+	}
+
+	async function ensureVm(ctx: ExtensionContext): Promise<EnclaveVM | null> {
+		if (!isActive()) return null;
+
+		if (enclaveVm?.isRunning) return enclaveVm;
+		if (vmStarting) return vmStarting;
+
+		vmStarting = (async () => {
+			ctx.ui.setStatus("enclave", "🧊 Starting VM...");
+
+			const instance = new EnclaveVM({
+				workspaceDir: localCwd,
+				packages,
+				extraMounts,
+				secrets,
+				gitCredentials,
+				extraEnv,
+				setupScript,
+				allowedHosts,
+				policies,
+				onPolicyPrompt: async (method, url, hostname) => {
+					if (!ctx.hasUI) return false;
+					return ctx.ui.confirm(
+						"Network request needs approval",
+						`${method} ${url}\nHost: ${hostname}\n\nAllow this request?`,
+					);
+				},
+				onStatus: (message) => {
+					ctx.ui.setStatus("enclave", `🧊 ${message}`);
+				},
+			});
+
+			await instance.start();
+			enclaveVm = instance;
+			ctx.ui.setStatus("enclave", "🧊 Enclave active");
+			setTimeout(() => ctx.ui.setStatus("enclave", undefined), 5000);
+
+			return instance;
+		})();
+
+		return vmStarting;
+	}
+
+	// -----------------------------------------------------------------------
+	// Session start: restore override, show hint if not configured
+	// -----------------------------------------------------------------------
+	pi.on("session_start", async (_event, ctx) => {
+		// Restore session override from log (handles resume)
+		const prev = getSessionActivation(ctx);
+		if (prev !== undefined) {
+			sessionOverride = prev;
+		}
+
+		if (isActive()) {
+			// Start VM eagerly so it's ready when the first tool runs
+			ensureVm(ctx);
+		} else if (configEnabled === undefined && sessionOverride === undefined) {
+			ctx.ui.notify("🧊 pi-enclave is installed but not enabled. Run /enclave init to set up.");
+		}
+	});
+
+	pi.on("session_switch", async (_event, ctx) => {
+		await shutdownVm();
+		ctx.ui.setStatus("enclave", undefined);
+		// Restore from new session's log
+		sessionOverride = getSessionActivation(ctx);
+
+		if (isActive()) {
+			ensureVm(ctx);
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// Register VM-backed tools
+	// -----------------------------------------------------------------------
+	const localRead = createReadTool(localCwd);
+	const localWrite = createWriteTool(localCwd);
+	const localEdit = createEditTool(localCwd);
+	const localBash = createBashTool(localCwd);
+
+	pi.registerTool({
+		...localRead,
+		async execute(id, params, signal, onUpdate, ctx) {
+			const vm = await ensureVm(ctx);
+			if (!vm) return localRead.execute(id, params, signal, onUpdate);
+			return createReadTool(localCwd, { operations: createVmReadOps(vm.rawVm) }).execute(id, params, signal, onUpdate);
+		},
+	});
+
+	pi.registerTool({
+		...localWrite,
+		async execute(id, params, signal, onUpdate, ctx) {
+			const vm = await ensureVm(ctx);
+			if (!vm) return localWrite.execute(id, params, signal, onUpdate);
+			return createWriteTool(localCwd, { operations: createVmWriteOps(vm.rawVm) }).execute(
+				id,
+				params,
+				signal,
+				onUpdate,
+			);
+		},
+	});
+
+	pi.registerTool({
+		...localEdit,
+		async execute(id, params, signal, onUpdate, ctx) {
+			const vm = await ensureVm(ctx);
+			if (!vm) return localEdit.execute(id, params, signal, onUpdate);
+			return createEditTool(localCwd, { operations: createVmEditOps(vm.rawVm) }).execute(id, params, signal, onUpdate);
+		},
+	});
+
+	pi.registerTool({
+		...localBash,
+		async execute(id, params, signal, onUpdate, ctx) {
+			const vm = await ensureVm(ctx);
+			if (!vm) return localBash.execute(id, params, signal, onUpdate);
+			return createBashTool(localCwd, { operations: createVmBashOps(vm.rawVm) }).execute(id, params, signal, onUpdate);
+		},
+	});
+
+	pi.on("user_bash", (_event, _ctx) => {
+		if (!enclaveVm?.isRunning) return;
+		return { operations: createVmBashOps(enclaveVm.rawVm) };
+	});
+
+	// -----------------------------------------------------------------------
+	// System prompt (only when active)
+	// -----------------------------------------------------------------------
+	pi.on("before_agent_start", async (_event, _ctx) => {
+		if (!isActive()) return;
+		return {
+			message: {
+				customType: "enclave:info",
+				content: [
+					{
+						type: "text" as const,
+						text: "Commands run inside an isolated Alpine Linux VM (pi-enclave). If a command is not found, ask the user to install it with `/enclave add <tool-name>`. Package names may differ from binary names (e.g. `github-cli` for `gh`).",
+					},
+				],
+				display: false,
+			},
+		};
+	});
+
+	// -----------------------------------------------------------------------
+	// Commands
+	// -----------------------------------------------------------------------
+	pi.registerCommand("enclave", {
+		description: "Manage enclave: /enclave [status|init|on|off|restart|add <pkg>]",
+		handler: async (args, ctx) => {
+			const parts = args.trim().split(/\s+/);
+			const subcommand = parts[0] || "status";
+
+			switch (subcommand) {
+				case "status": {
+					const lines: string[] = [];
+
+					// State
+					if (enclaveVm?.isRunning) {
+						lines.push("🧊 Enclave active");
+					} else if (isActive()) {
+						lines.push("🧊 Enabled, VM starts on next tool use");
+					} else {
+						lines.push("🧊 Not enabled");
+					}
+					lines.push("");
+
+					// Config sources
+					const configLines: string[] = [];
+					if (hasGlobalConfig) configLines.push(`  ${tildify(globalConfigPath())}`);
+					if (dropIns.length) configLines.push(`  ${tildify(globalDropInDir())}/*`);
+					if (hasProjectConfig) configLines.push(`  ${tildify(join(localCwd, ".pi", "enclave.toml"))}`);
+					if (configLines.length) {
+						lines.push("Config:");
+						lines.push(...configLines);
+					} else {
+						lines.push("Config: none");
+					}
+					lines.push("");
+
+					// What's inside
+					lines.push(`Packages:  ${packages.join(", ")}`);
+
+					const secretNames = secrets.map((s) => s.name).join(", ");
+					if (secretNames) lines.push(`Secrets:   ${secretNames}`);
+
+					const envNames = Object.keys(extraEnv).join(", ");
+					if (envNames) lines.push(`Env:       ${envNames}`);
+
+					const hostNames = [...policies.keys()].join(", ");
+					if (hostNames) lines.push(`Policies:  ${hostNames}`);
+
+					ctx.ui.notify(lines.join("\n"));
+					break;
+				}
+
+				case "init": {
+					const createdGlobal = ensureGlobalConfig();
+					const createdProject = initProjectConfig(localCwd);
+
+					const messages: string[] = [];
+					for (const path of createdGlobal) {
+						messages.push(`Created ${tildify(path)}`);
+					}
+					if (createdProject) {
+						messages.push("Created .pi/enclave.toml with enabled = true");
+						// Activate for this session too
+						sessionOverride = true;
+						pi.appendEntry(SESSION_ENTRY_TYPE, true);
+					} else {
+						messages.push(".pi/enclave.toml already exists");
+					}
+
+					ctx.ui.notify(`🧊 ${messages.join("\n")}`);
+
+					if (createdProject) {
+						ctx.ui.notify("Reload with /reload to apply the new config.", "info");
+					}
+					break;
+				}
+
+				case "on": {
+					sessionOverride = true;
+					pi.appendEntry(SESSION_ENTRY_TYPE, true);
+					ctx.ui.notify("🧊 pi-enclave enabled for this session. VM starts on next tool use.");
+					break;
+				}
+
+				case "off": {
+					sessionOverride = false;
+					pi.appendEntry(SESSION_ENTRY_TYPE, false);
+					await shutdownVm();
+					ctx.ui.setStatus("enclave", undefined);
+					ctx.ui.notify("🧊 pi-enclave disabled for this session. Tools run on the host.");
+					break;
+				}
+
+				case "restart": {
+					await shutdownVm();
+					ctx.ui.notify("🧊 pi-enclave: VM will restart on next tool use.");
+					break;
+				}
+
+				case "add": {
+					const query = parts.slice(1).join(" ");
+					if (!query) {
+						ctx.ui.notify("Usage: /enclave add <package-name>", "warning");
+						return;
+					}
+
+					// Enable for this session if not already
+					if (!isActive()) {
+						sessionOverride = true;
+						pi.appendEntry(SESSION_ENTRY_TYPE, true);
+					}
+
+					const vmForAdd = await ensureVm(ctx);
+					if (!vmForAdd) {
+						ctx.ui.notify("Failed to start VM.", "error");
+						return;
+					}
+					await handleAddPackage(query, vmForAdd, localCwd, ctx);
+					break;
+				}
+
+				default:
+					ctx.ui.notify("Usage: /enclave [status|init|on|off|restart|add <pkg>]", "warning");
+			}
+		},
+	});
+
+	// -----------------------------------------------------------------------
+	// Shutdown
+	// -----------------------------------------------------------------------
+	pi.on("session_shutdown", async (_event, ctx) => {
+		if (!enclaveVm) return;
+		ctx.ui.setStatus("enclave", "🧊 Stopping enclave...");
+		await shutdownVm();
+	});
+}

--- a/packages/enclave/src/policy.ts
+++ b/packages/enclave/src/policy.ts
@@ -1,0 +1,105 @@
+/**
+ * HTTP method+path policy enforcement.
+ *
+ * Per-host rules define allowed methods and path patterns.
+ * Deny patterns always win. Unmatched requests can prompt, deny, or allow.
+ */
+
+import type { ResolvedHostPolicy } from "./config.js";
+
+export type PolicyDecision = "allow" | "deny" | "prompt";
+
+/**
+ * Match a URL path against a pattern.
+ *
+ * Pattern syntax:
+ * - `*` (single star) matches exactly one path segment
+ * - `**` (double star) matches the rest of the path (must be last)
+ * - Literal segments match exactly
+ */
+export function matchPath(pattern: string, path: string): boolean {
+	// Normalize: ensure leading slash, strip trailing slash
+	const normPattern = pattern.startsWith("/") ? pattern : `/${pattern}`;
+	const normPath = path.startsWith("/") ? path : `/${path}`;
+
+	const patternParts = normPattern.split("/").filter(Boolean);
+	const pathParts = normPath.split("/").filter(Boolean);
+
+	let pi = 0;
+	let pp = 0;
+
+	while (pi < patternParts.length && pp < pathParts.length) {
+		const pat = patternParts[pi];
+
+		if (pat === "**") {
+			// ** matches zero or more remaining segments
+			return true;
+		}
+
+		if (pat === "*") {
+			// Match exactly one segment
+			pi++;
+			pp++;
+			continue;
+		}
+
+		// Literal match
+		if (pat !== pathParts[pp]) {
+			return false;
+		}
+
+		pi++;
+		pp++;
+	}
+
+	// ** at the end matches zero remaining segments
+	if (pi < patternParts.length && patternParts[pi] === "**") {
+		return true;
+	}
+
+	// Both must be exhausted
+	return pi === patternParts.length && pp === pathParts.length;
+}
+
+/**
+ * Check a request against a host policy.
+ */
+export function checkPolicy(policy: ResolvedHostPolicy, method: string, path: string): PolicyDecision {
+	const upperMethod = method.toUpperCase();
+
+	// Deny patterns always win
+	for (const pattern of policy.deny) {
+		if (matchPath(pattern, path)) {
+			return "deny";
+		}
+	}
+
+	// Check method-specific allows
+	const allowedPatterns = policy.allows.get(upperMethod);
+	if (allowedPatterns) {
+		for (const pattern of allowedPatterns) {
+			if (matchPath(pattern, path)) {
+				return "allow";
+			}
+		}
+	}
+
+	// No explicit allow matched
+	return policy.unmatched;
+}
+
+/**
+ * Evaluate an HTTP request against all policies.
+ *
+ * Returns "allow" if no policy exists for the host (open by default).
+ */
+export function evaluateRequest(
+	policies: Map<string, ResolvedHostPolicy>,
+	hostname: string,
+	method: string,
+	path: string,
+): PolicyDecision {
+	const policy = policies.get(hostname);
+	if (!policy) return "allow";
+	return checkPolicy(policy, method, path);
+}

--- a/packages/enclave/src/secrets.ts
+++ b/packages/enclave/src/secrets.ts
@@ -1,0 +1,118 @@
+/**
+ * Secret resolution for pi-enclave.
+ *
+ * Secrets are sourced from the host and never enter the VM.
+ * The VM sees placeholder values; the Gondolin HTTP proxy substitutes
+ * real values only for requests to configured hosts.
+ *
+ * All secrets are explicitly configured in .pi/enclave.toml or the
+ * global config. There is no auto-detection.
+ */
+
+import { execSync } from "node:child_process";
+import type { EnvDef, ResolvedSecret, SecretDef } from "./config.js";
+
+export type { ResolvedSecret } from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function commandExists(cmd: string): boolean {
+	try {
+		execSync(`which ${cmd}`, { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function runCommand(command: string): string | undefined {
+	try {
+		const result = execSync(command, {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 10_000,
+		});
+		const trimmed = result.trim();
+		return trimmed || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single secret definition into a value + hosts, or undefined if
+ * the source is unavailable (tool not installed, env var not set, etc.).
+ */
+function resolveSource(name: string, source: SecretDef): ResolvedSecret | undefined {
+	if (source === false) return undefined;
+
+	if ("command" in source) {
+		// Check if the command's binary exists before running it
+		const binary = source.command.split(/\s+/)[0];
+		if (binary && !commandExists(binary)) return undefined;
+
+		const value = runCommand(source.command);
+		if (!value) return undefined;
+		return { name, value, hosts: source.hosts };
+	}
+
+	if ("env" in source) {
+		const value = process.env[source.env];
+		if (!value) return undefined;
+		return { name, value, hosts: source.hosts };
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolve all secrets from config.
+ * Secrets whose source is unavailable (command not found, env var not set)
+ * are silently skipped.
+ */
+export function resolveSecrets(configSecrets: Record<string, SecretDef> = {}): ResolvedSecret[] {
+	const resolved: ResolvedSecret[] = [];
+
+	for (const [name, source] of Object.entries(configSecrets)) {
+		const secret = resolveSource(name, source);
+		if (secret) resolved.push(secret);
+	}
+
+	return resolved;
+}
+
+/**
+ * Resolve environment variable definitions into key-value pairs.
+ * Entries whose source is unavailable are silently skipped.
+ */
+export function resolveEnv(configEnv: Record<string, EnvDef> = {}): Record<string, string> {
+	const resolved: Record<string, string> = {};
+
+	for (const [name, def] of Object.entries(configEnv)) {
+		if (typeof def === "string") {
+			resolved[name] = def;
+			continue;
+		}
+
+		if ("command" in def) {
+			const binary = def.command.split(/\s+/)[0];
+			if (binary && !commandExists(binary)) continue;
+			const value = runCommand(def.command);
+			if (value) resolved[name] = value;
+			continue;
+		}
+
+		if ("env" in def) {
+			const value = process.env[def.env];
+			if (value) resolved[name] = value;
+		}
+	}
+
+	return resolved;
+}

--- a/packages/enclave/src/tools.ts
+++ b/packages/enclave/src/tools.ts
@@ -1,0 +1,123 @@
+/**
+ * VM-backed tool operations.
+ *
+ * Implementations of pi's ReadOperations, WriteOperations, EditOperations,
+ * and BashOperations that delegate to a Gondolin VM. Since the workspace is
+ * mounted at the same path inside the VM as on the host, paths are passed
+ * through unchanged.
+ */
+
+import path from "node:path";
+import type { VM } from "@earendil-works/gondolin";
+import type { BashOperations, EditOperations, ReadOperations, WriteOperations } from "@mariozechner/pi-coding-agent";
+
+export function shQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function createVmReadOps(vm: VM): ReadOperations {
+	return {
+		readFile: async (p) => {
+			const r = await vm.exec(["/bin/cat", p]);
+			if (!r.ok) throw new Error(`cat failed (${r.exitCode}): ${r.stderr}`);
+			return r.stdoutBuffer;
+		},
+		access: async (p) => {
+			const r = await vm.exec(["/bin/sh", "-lc", `test -r ${shQuote(p)}`]);
+			if (!r.ok) throw new Error(`not readable: ${p}`);
+		},
+		detectImageMimeType: async (p) => {
+			try {
+				const r = await vm.exec(["/bin/sh", "-lc", `file --mime-type -b ${shQuote(p)}`]);
+				if (!r.ok) return null;
+				const m = r.stdout.trim();
+				return ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(m) ? m : null;
+			} catch {
+				return null;
+			}
+		},
+	};
+}
+
+export function createVmWriteOps(vm: VM): WriteOperations {
+	return {
+		writeFile: async (p, content) => {
+			const dir = path.posix.dirname(p);
+			const b64 = Buffer.from(content, "utf8").toString("base64");
+			const script = ["set -eu", `mkdir -p ${shQuote(dir)}`, `echo ${shQuote(b64)} | base64 -d > ${shQuote(p)}`].join(
+				"\n",
+			);
+			const r = await vm.exec(["/bin/sh", "-lc", script]);
+			if (!r.ok) throw new Error(`write failed (${r.exitCode}): ${r.stderr}`);
+		},
+		mkdir: async (dir) => {
+			const r = await vm.exec(["/bin/mkdir", "-p", dir]);
+			if (!r.ok) throw new Error(`mkdir failed (${r.exitCode}): ${r.stderr}`);
+		},
+	};
+}
+
+export function createVmEditOps(vm: VM): EditOperations {
+	const r = createVmReadOps(vm);
+	const w = createVmWriteOps(vm);
+	return { readFile: r.readFile, access: r.access, writeFile: w.writeFile };
+}
+
+/**
+ * Strip host environment variables. The VM has its own clean environment;
+ * we only pass through non-secret variables like TERM, LANG, etc.
+ * Secrets are injected by the HTTP proxy, not via env vars.
+ */
+const ENV_PASSTHROUGH = new Set(["TERM", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "EDITOR", "VISUAL", "PAGER"]);
+
+function sanitizeEnv(env?: NodeJS.ProcessEnv): Record<string, string> | undefined {
+	if (!env) return undefined;
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(env)) {
+		if (typeof v === "string" && ENV_PASSTHROUGH.has(k)) out[k] = v;
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function createVmBashOps(vm: VM): BashOperations {
+	return {
+		exec: async (command, cwd, { onData, signal, timeout, env }) => {
+			const ac = new AbortController();
+			const onAbort = () => ac.abort();
+			signal?.addEventListener("abort", onAbort, { once: true });
+
+			let timedOut = false;
+			const timer =
+				timeout && timeout > 0
+					? setTimeout(() => {
+							timedOut = true;
+							ac.abort();
+						}, timeout * 1000)
+					: undefined;
+
+			try {
+				const proc = vm.exec(["/bin/sh", "-lc", command], {
+					cwd,
+					signal: ac.signal,
+					env: sanitizeEnv(env),
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+
+				for await (const chunk of proc.output()) {
+					onData(chunk.data);
+				}
+
+				const r = await proc;
+				return { exitCode: r.exitCode };
+			} catch (err) {
+				if (signal?.aborted) throw new Error("aborted");
+				if (timedOut) throw new Error(`timeout:${timeout}`);
+				throw err;
+			} finally {
+				if (timer) clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
+			}
+		},
+	};
+}

--- a/packages/enclave/src/vm.ts
+++ b/packages/enclave/src/vm.ts
@@ -1,0 +1,340 @@
+/**
+ * VM lifecycle management.
+ *
+ * Creates and manages the Gondolin micro-VM, wiring up:
+ * - Workspace mount (RealFSProvider with ShadowProvider for config protection)
+ * - HTTP hooks (secret injection + policy enforcement)
+ * - Package installation
+ */
+
+import { execSync } from "node:child_process";
+import {
+	type CreateHttpHooksOptions,
+	type ExecResult,
+	RealFSProvider,
+	type SecretDefinition,
+	ShadowProvider,
+	VM,
+	createHttpHooks,
+	createShadowPathPredicate,
+} from "@earendil-works/gondolin";
+
+import type { GitCredentialDef, ResolvedHostPolicy, ResolvedSecret } from "./config.js";
+import { checkGraphQLPolicy, parseGraphQLBody } from "./graphql.js";
+import { evaluateRequest } from "./policy.js";
+
+export interface ExtraMount {
+	path: string;
+	readonly: boolean;
+}
+
+export interface EnclaveVMOptions {
+	/** Host directory to mount inside the VM */
+	workspaceDir: string;
+	/** Alpine packages to install */
+	packages: string[];
+	/** Additional directories to mount in the VM */
+	extraMounts: ExtraMount[];
+	/** Resolved secrets for proxy injection */
+	secrets: ResolvedSecret[];
+	/** Git credential helpers to configure */
+	gitCredentials: GitCredentialDef[];
+	/** Extra env vars to set in the VM (non-secret, from config [env] section) */
+	extraEnv: Record<string, string>;
+	/** Concatenated setup scripts to run after package install */
+	setupScript: string | undefined;
+	/** Host allowlist (undefined = allow all) */
+	allowedHosts: string[] | undefined;
+	/** Per-host HTTP policies */
+	policies: Map<string, ResolvedHostPolicy>;
+	/** Callback when a request needs user prompt */
+	onPolicyPrompt?: (method: string, url: string, hostname: string) => Promise<boolean>;
+	/** Callback for debug/status messages */
+	onStatus?: (message: string) => void;
+}
+
+export class EnclaveVM {
+	private vm: VM | undefined;
+	private closed = false;
+	private readonly options: EnclaveVMOptions;
+
+	/** Access the underlying Gondolin VM for creating tool operations. */
+	get rawVm(): VM {
+		if (!this.vm) throw new Error("pi-enclave: VM not started");
+		return this.vm;
+	}
+
+	constructor(options: EnclaveVMOptions) {
+		this.options = options;
+	}
+
+	/**
+	 * Start the VM. Call once before exec().
+	 */
+	async start(): Promise<void> {
+		if (this.vm) return;
+		if (this.closed) throw new Error("pi-enclave: VM has been closed");
+
+		const { workspaceDir, secrets, allowedHosts, policies, onPolicyPrompt } = this.options;
+
+		this.options.onStatus?.("Starting VM...");
+
+		// Build secret definitions for Gondolin
+		const secretDefs: Record<string, SecretDefinition> = {};
+		for (const secret of secrets) {
+			secretDefs[secret.name] = {
+				hosts: secret.hosts,
+				value: secret.value,
+			};
+		}
+
+		// Build HTTP hooks
+		const hookOptions: CreateHttpHooksOptions = {
+			secrets: secretDefs,
+			blockInternalRanges: true,
+		};
+
+		// Gondolin's createHttpHooks builds an allowlist from secret hosts.
+		// If that list is non-empty, only those hosts are reachable.
+		// We must always include Alpine repos (for apk) and, when the user
+		// configured an explicit allowlist, merge that in too.
+		const secretHosts = secrets.flatMap((s) => s.hosts);
+		const needsAllowlist = allowedHosts || secretHosts.length > 0;
+		if (needsAllowlist) {
+			hookOptions.allowedHosts = [...(allowedHosts ?? []), "dl-cdn.alpinelinux.org", ...secretHosts];
+		}
+
+		// Policy enforcement via isRequestAllowed (method + path).
+		// For hosts with a graphql policy, POST to the graphql endpoint is
+		// allowed at this level; the onRequest hook does deeper inspection.
+		if (policies.size > 0) {
+			hookOptions.isRequestAllowed = async (request: Request) => {
+				const url = new URL(request.url);
+				const hostPolicy = policies.get(url.hostname);
+
+				// If the request targets a GraphQL endpoint that has a policy,
+				// let it through to onRequest for body-level inspection.
+				if (hostPolicy?.graphql && request.method === "POST" && url.pathname === hostPolicy.graphql.endpoint) {
+					return true;
+				}
+
+				const decision = evaluateRequest(policies, url.hostname, request.method, url.pathname);
+
+				if (decision === "allow") return true;
+				if (decision === "deny") return false;
+
+				// "prompt" - ask user if callback provided, otherwise deny
+				if (decision === "prompt" && onPolicyPrompt) {
+					return onPolicyPrompt(request.method, request.url, url.hostname);
+				}
+
+				return false;
+			};
+		}
+
+		// GraphQL policy enforcement via onRequest (has access to body).
+		// When a host has a graphql policy, parse the body and check
+		// operations against the allow lists.
+		hookOptions.onRequest = async (request: Request) => {
+			if (request.method !== "POST") return;
+			const url = new URL(request.url);
+
+			// Find the host policy with a matching GraphQL endpoint
+			const hostPolicy = policies.get(url.hostname);
+			if (!hostPolicy?.graphql || url.pathname !== hostPolicy.graphql.endpoint) return;
+
+			const gqlPolicy = hostPolicy.graphql;
+
+			// Parse the GraphQL body
+			let bodyText: string;
+			try {
+				const cloned = request.clone();
+				bodyText = await cloned.text();
+			} catch {
+				return;
+			}
+
+			const operations = parseGraphQLBody(bodyText);
+			if (!operations) {
+				// Can't parse the GraphQL body. Fail closed: treat as denied.
+				if (gqlPolicy.unmatched === "allow") return;
+				return new Response(
+					JSON.stringify({ errors: [{ message: "Blocked by pi-enclave: unparseable GraphQL body" }] }),
+					{ status: 403, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (operations.length === 0) return;
+
+			const result = checkGraphQLPolicy(operations, gqlPolicy.allow);
+			if (result.allowed) return;
+
+			// Some operations were denied, check unmatched policy
+			if (gqlPolicy.unmatched === "allow") return;
+			if (gqlPolicy.unmatched === "deny") {
+				return new Response(
+					JSON.stringify({ errors: [{ message: `Blocked by pi-enclave: ${result.deniedFields.join(", ")}` }] }),
+					{ status: 403, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			// Prompt user
+			if (onPolicyPrompt) {
+				const fieldList = result.deniedFields.join(", ");
+				const allowed = await onPolicyPrompt(
+					"GRAPHQL",
+					`${url.hostname}${gqlPolicy.endpoint}: ${fieldList}`,
+					url.hostname,
+				);
+				if (!allowed) {
+					return new Response(JSON.stringify({ errors: [{ message: `Blocked by pi-enclave: ${fieldList}` }] }), {
+						status: 403,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+			} else {
+				return new Response(JSON.stringify({ errors: [{ message: "Blocked by pi-enclave policy" }] }), {
+					status: 403,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+		};
+
+		const { httpHooks, env } = createHttpHooks(hookOptions);
+
+		// Build VFS: mount workspace at the same path as on the host.
+		// This makes the VM transparent: paths match between host and guest.
+		const realFs = new RealFSProvider(workspaceDir);
+		const shadowedFs = new ShadowProvider(realFs, {
+			shouldShadow: createShadowPathPredicate(["/.pi/enclave.toml"]),
+			writeMode: "deny",
+		});
+
+		const mounts: Record<string, RealFSProvider | ShadowProvider> = {
+			[workspaceDir]: shadowedFs,
+		};
+
+		// Extra mounts (e.g. jj repo root, shared directories)
+		for (const extra of this.options.extraMounts) {
+			if (mounts[extra.path]) continue; // workspace already mounted
+			const provider = new RealFSProvider(extra.path);
+			if (extra.readonly) {
+				mounts[extra.path] = new ShadowProvider(provider, {
+					shouldShadow: () => true,
+					writeMode: "deny",
+				});
+			} else {
+				mounts[extra.path] = provider;
+			}
+		}
+
+		// Create and start VM
+		this.vm = await VM.create({
+			httpHooks,
+			env: {
+				...env,
+				...this.options.extraEnv,
+				HOME: "/root",
+				TERM: "xterm-256color",
+			},
+			vfs: {
+				mounts,
+			},
+			sessionLabel: "pi-enclave",
+		});
+
+		this.options.onStatus?.("Installing packages...");
+
+		// Install packages first (git, jj, etc. aren't in base Alpine)
+		const packages = this.options.packages;
+		if (packages.length > 0) {
+			const result = await this.vm.exec(`apk add --no-progress ${packages.map(shellEscape).join(" ")}`);
+			if (!result.ok) {
+				this.options.onStatus?.(`Enclave active (package install warning: ${result.stderr.trim().split("\n").pop()})`);
+				return;
+			}
+		}
+
+		// Git: credential helpers from config
+		// Secret env vars contain Gondolin placeholders; the HTTP proxy
+		// decodes Basic auth, swaps placeholders for real values, re-encodes.
+		for (const cred of this.options.gitCredentials) {
+			await this.vm.exec(
+				`git config --global credential.https://${shellEscape(cred.host)}.helper ` +
+					`'!f() { echo "username=${shellEscape(cred.username)}"; echo "password=$${cred.secret}"; }; f'`,
+			);
+		}
+
+		// Run setup scripts from config (each drop-in's setup, concatenated)
+		if (this.options.setupScript) {
+			this.options.onStatus?.("Running setup...");
+			const result = await this.vm.exec(this.options.setupScript);
+			if (!result.ok) {
+				this.options.onStatus?.(`Enclave active (setup warning: ${result.stderr.trim().split("\n").pop()})`);
+				return;
+			}
+		}
+
+		this.options.onStatus?.("VM ready");
+	}
+
+	/**
+	 * Install additional packages at runtime.
+	 */
+	async installPackage(pkg: string): Promise<ExecResult> {
+		if (!this.vm) throw new Error("pi-enclave: VM not started");
+		return this.vm.exec(`apk add --no-progress ${shellEscape(pkg)}`);
+	}
+
+	/**
+	 * Check if the VM is running.
+	 */
+	get isRunning(): boolean {
+		return this.vm !== undefined && !this.closed;
+	}
+
+	/**
+	 * Shut down the VM.
+	 */
+	async close(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		if (this.vm) {
+			await this.vm.close();
+			this.vm = undefined;
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function shellEscape(s: string): string {
+	return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Check if QEMU is available on the host.
+ */
+export function checkQemuAvailable(): { available: boolean; message?: string } {
+	try {
+		execSync("which qemu-system-aarch64", { stdio: "ignore" });
+		return { available: true };
+	} catch {
+		const platform = process.platform;
+		let installHint: string;
+		if (platform === "darwin") {
+			installHint = "Install with: brew install qemu";
+		} else if (platform === "linux") {
+			installHint =
+				"Install with: sudo apt install qemu-system-aarch64 (Debian/Ubuntu) or sudo pacman -S qemu-full (Arch)";
+		} else {
+			installHint = "QEMU is required but your platform may not be supported.";
+		}
+
+		return {
+			available: false,
+			message: `pi-enclave requires QEMU but qemu-system-aarch64 was not found.\n${installHint}`,
+		};
+	}
+}

--- a/packages/enclave/templates/pi-enclave.d/git.toml
+++ b/packages/enclave/templates/pi-enclave.d/git.toml
@@ -1,0 +1,7 @@
+# Git support for pi-enclave
+packages = ["git"]
+setup = """
+git config --global safe.directory '*'
+git config --global user.name "$USER_NAME"
+git config --global user.email "$USER_EMAIL"
+"""

--- a/packages/enclave/templates/pi-enclave.d/github.toml
+++ b/packages/enclave/templates/pi-enclave.d/github.toml
@@ -1,0 +1,41 @@
+# GitHub service policy for pi-enclave
+# Drop-in file: delete this file to disable GitHub integration.
+
+packages = ["github-cli"]
+
+# Secret: how to get the token, where the proxy injects it
+[secrets.GH_TOKEN]
+command = "gh auth token"
+hosts = ["api.github.com", "github.com", "*.githubusercontent.com"]
+
+# Git: how git authenticates over HTTPS
+[[git-credentials]]
+host = "github.com"
+username = "x-access-token"
+secret = "GH_TOKEN"
+
+# github.com: git smart HTTP protocol.
+# Fetch/clone use POST /git-upload-pack (read), push uses POST /git-receive-pack (write).
+[hosts."github.com"]
+unmatched = "prompt"
+allow.GET = ["/**"]
+allow.POST = ["/**/git-upload-pack"]
+
+# GitHub API: allow reads, prompt for writes.
+# pi-enclave parses GraphQL request bodies and checks actual field
+# names (not the client-controlled operation name).
+[hosts."api.github.com"]
+unmatched = "prompt"
+allow.GET = ["/**"]
+
+[hosts."api.github.com".graphql]
+endpoint = "/graphql"
+allow.query = ["*"]
+allow.mutation = [
+  "createPullRequest",
+  "createIssue",
+  "addComment",
+  "addPullRequestReview",
+  "updatePullRequest",
+  "updateIssue",
+]

--- a/packages/enclave/templates/pi-enclave.d/jj.toml
+++ b/packages/enclave/templates/pi-enclave.d/jj.toml
@@ -1,0 +1,11 @@
+# Jujutsu (jj) support for pi-enclave
+# For jj workspaces, add a mount for the parent .jj directory in your
+# project config:
+#
+# [[mounts]]
+# path = "~/dev/myproject/.jj"
+packages = ["jujutsu"]
+setup = """
+jj config set --user user.name "$USER_NAME"
+jj config set --user user.email "$USER_EMAIL"
+"""

--- a/packages/enclave/templates/pi-enclave.toml
+++ b/packages/enclave/templates/pi-enclave.toml
@@ -1,0 +1,22 @@
+# pi-enclave global configuration
+# See: https://github.com/mgabor3141/yapp/tree/main/packages/enclave
+
+# Default for projects without their own .pi/enclave.toml:
+# enabled = false
+
+# Base packages (drop-in files in pi-enclave.d/ add more):
+packages = ["curl", "jq"]
+
+# Environment variables available in the VM and setup scripts.
+# Values can be static strings, host commands, or host env vars.
+[env]
+USER_NAME = { command = "git config --global user.name" }
+USER_EMAIL = { command = "git config --global user.email" }
+
+# Service policies live in pi-enclave.d/ as drop-in files.
+# See pi-enclave.d/ for examples.
+
+# Additional secrets:
+# [secrets.OPENAI_API_KEY]
+# env = "OPENAI_API_KEY"
+# hosts = ["api.openai.com"]

--- a/packages/enclave/templates/project.toml
+++ b/packages/enclave/templates/project.toml
@@ -1,0 +1,7 @@
+# pi-enclave: run tools in an isolated VM
+# Protects API keys and isolates file access.
+enabled = true
+
+# Mount additional directories in the VM (supports ~):
+# [[mounts]]
+# path = "~/dev/myproject/.jj"

--- a/packages/enclave/test/config.test.ts
+++ b/packages/enclave/test/config.test.ts
@@ -1,0 +1,303 @@
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PACKAGES, EnclaveFileConfig, mergeConfigs, resolveHostPolicies } from "../src/config.js";
+
+describe("EnclaveFileConfig schema", () => {
+	it("accepts empty config", () => {
+		const result = v.parse(EnclaveFileConfig, {});
+		expect(result.enabled).toBeUndefined();
+		expect(result.packages).toBeUndefined();
+		expect(result.secrets).toEqual({});
+		expect(result.hosts).toEqual({});
+	});
+
+	it("accepts enabled = true", () => {
+		const result = v.parse(EnclaveFileConfig, { enabled: true });
+		expect(result.enabled).toBe(true);
+	});
+
+	it("accepts enabled = false", () => {
+		const result = v.parse(EnclaveFileConfig, { enabled: false });
+		expect(result.enabled).toBe(false);
+	});
+
+	it("accepts full config", () => {
+		const result = v.parse(EnclaveFileConfig, {
+			enabled: true,
+			packages: ["git", "curl", "ripgrep"],
+			secrets: {
+				GH_TOKEN: { command: "gh auth token", hosts: ["api.github.com"] },
+				OPENAI_API_KEY: { env: "OPENAI_API_KEY", hosts: ["api.openai.com"] },
+			},
+			hosts: {
+				"api.github.com": {
+					allow: { GET: ["/**"] },
+					deny: ["/repos/*/*/pulls/*/merge"],
+					unmatched: "prompt",
+					graphql: {
+						endpoint: "/graphql",
+						allow: { query: ["*"], mutation: ["createPullRequest"] },
+					},
+				},
+			},
+		});
+
+		expect(result.packages).toEqual(["git", "curl", "ripgrep"]);
+		expect(result.secrets?.GH_TOKEN).toEqual({
+			command: "gh auth token",
+			hosts: ["api.github.com"],
+		});
+		const host = result.hosts?.["api.github.com"];
+		expect(host?.deny).toEqual(["/repos/*/*/pulls/*/merge"]);
+		expect(host?.unmatched).toBe("prompt");
+		expect(host?.graphql?.endpoint).toBe("/graphql");
+		expect(host?.graphql?.allow.mutation).toEqual(["createPullRequest"]);
+	});
+
+	it("accepts false to disable a secret", () => {
+		const result = v.parse(EnclaveFileConfig, {
+			secrets: { GH_TOKEN: false },
+		});
+		expect(result.secrets?.GH_TOKEN).toBe(false);
+	});
+
+	it("accepts host with just secret reference", () => {
+		const result = v.parse(EnclaveFileConfig, {
+			hosts: { "github.com": { secret: "GH_TOKEN" } },
+		});
+		expect(result.hosts?.["github.com"]?.secret).toBe("GH_TOKEN");
+	});
+
+	it("rejects invalid unmatched value", () => {
+		expect(() =>
+			v.parse(EnclaveFileConfig, {
+				hosts: {
+					"example.com": { unmatched: "maybe" },
+				},
+			}),
+		).toThrow();
+	});
+});
+
+describe("mergeConfigs", () => {
+	it("returns defaults with empty layers", () => {
+		const result = mergeConfigs([]);
+		expect(result.packages).toEqual([]);
+		expect(result.secrets).toEqual({});
+		expect(result.hosts).toEqual({});
+	});
+
+	it("later enabled wins", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, { enabled: false }),
+			v.parse(EnclaveFileConfig, { enabled: true }),
+		]);
+		expect(result.enabled).toBe(true);
+	});
+
+	it("enabled stays undefined when not set", () => {
+		const result = mergeConfigs([v.parse(EnclaveFileConfig, {})]);
+		expect(result.enabled).toBeUndefined();
+	});
+
+	it("packages accumulate across layers, deduplicated", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, { packages: ["git", "curl"] }),
+			v.parse(EnclaveFileConfig, { packages: ["git", "ripgrep"] }),
+		]);
+		expect(result.packages).toEqual(["git", "curl", "ripgrep"]);
+	});
+
+	it("secrets merge by key, later wins", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, {
+				secrets: {
+					GH_TOKEN: { command: "old-cmd", hosts: ["github.com"] },
+					OTHER: { env: "OTHER", hosts: ["other.com"] },
+				},
+			}),
+			v.parse(EnclaveFileConfig, {
+				secrets: {
+					GH_TOKEN: { command: "new-cmd", hosts: ["api.github.com"] },
+				},
+			}),
+		]);
+
+		expect(result.secrets?.GH_TOKEN).toEqual({
+			command: "new-cmd",
+			hosts: ["api.github.com"],
+		});
+		expect(result.secrets?.OTHER).toEqual({ env: "OTHER", hosts: ["other.com"] });
+	});
+
+	it("false disables a secret from earlier layer", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, {
+				secrets: { GH_TOKEN: { command: "gh auth token", hosts: ["github.com"] } },
+			}),
+			v.parse(EnclaveFileConfig, {
+				secrets: { GH_TOKEN: false },
+			}),
+		]);
+		expect(result.secrets?.GH_TOKEN).toBe(false);
+	});
+
+	it("mounts accumulate across layers, later wins on same path", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, {
+				mounts: [{ path: "/home/user/.jj", readonly: false }],
+			}),
+			v.parse(EnclaveFileConfig, {
+				mounts: [{ path: "/home/user/.jj", readonly: true }, { path: "/home/user/other" }],
+			}),
+		]);
+		expect(result.mounts).toHaveLength(2);
+		expect(result.mounts).toContainEqual({ path: "/home/user/.jj", readonly: true });
+		expect(result.mounts).toContainEqual({ path: "/home/user/other", readonly: false });
+	});
+
+	it("env merges by key, later wins", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, {
+				env: { USER_NAME: "Alice", EDITOR: "vim" },
+			}),
+			v.parse(EnclaveFileConfig, {
+				env: { USER_NAME: { command: "whoami" } },
+			}),
+		]);
+		expect(result.env?.USER_NAME).toEqual({ command: "whoami" });
+		expect(result.env?.EDITOR).toBe("vim");
+	});
+
+	it("setup scripts concatenate across layers", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, { setup: "echo git" }),
+			v.parse(EnclaveFileConfig, {}),
+			v.parse(EnclaveFileConfig, { setup: "echo jj" }),
+		]);
+		expect(result.setup).toBe("echo git\necho jj");
+	});
+
+	it("hosts merge by key, later wins", () => {
+		const result = mergeConfigs([
+			v.parse(EnclaveFileConfig, {
+				hosts: { "api.github.com": { unmatched: "prompt", allow: { GET: ["/**"] } } },
+			}),
+			v.parse(EnclaveFileConfig, {
+				hosts: { "api.github.com": { unmatched: "allow" } },
+			}),
+		]);
+		expect(result.hosts?.["api.github.com"]?.unmatched).toBe("allow");
+	});
+});
+
+describe("resolveHostPolicies", () => {
+	it("resolves host policies from config", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: {
+				"api.github.com": {
+					allow: { GET: ["/repos/**"] },
+					deny: ["/admin/**"],
+					unmatched: "prompt",
+				},
+			},
+		});
+
+		const policies = resolveHostPolicies(config);
+		const policy = policies.get("api.github.com");
+
+		expect(policy).toBeDefined();
+		expect(policy!.hostname).toBe("api.github.com");
+		expect(policy!.allows.get("GET")).toEqual(["/repos/**"]);
+		expect(policy!.deny).toEqual(["/admin/**"]);
+		expect(policy!.unmatched).toBe("prompt");
+	});
+
+	it("uppercases method names", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: {
+				"example.com": {
+					allow: { get: ["/foo"], post: ["/bar"] },
+				},
+			},
+		});
+
+		const policies = resolveHostPolicies(config);
+		const policy = policies.get("example.com")!;
+		expect(policy.allows.has("GET")).toBe(true);
+		expect(policy.allows.has("POST")).toBe(true);
+	});
+
+	it("resolves graphql policy", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: {
+				"api.github.com": {
+					unmatched: "prompt",
+					graphql: {
+						endpoint: "/graphql",
+						allow: { query: ["*"], mutation: ["createPullRequest"] },
+					},
+				},
+			},
+		});
+
+		const policies = resolveHostPolicies(config);
+		const policy = policies.get("api.github.com")!;
+		expect(policy.graphql).toBeDefined();
+		expect(policy.graphql!.endpoint).toBe("/graphql");
+		expect(policy.graphql!.allow.query).toEqual(["*"]);
+		expect(policy.graphql!.allow.mutation).toEqual(["createPullRequest"]);
+	});
+
+	it("graphql inherits host unmatched", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: {
+				"api.github.com": {
+					unmatched: "deny",
+					graphql: {
+						endpoint: "/graphql",
+						allow: { query: ["*"] },
+					},
+				},
+			},
+		});
+
+		const policies = resolveHostPolicies(config);
+		expect(policies.get("api.github.com")!.graphql!.unmatched).toBe("deny");
+	});
+
+	it("graphql can override host unmatched", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: {
+				"api.github.com": {
+					unmatched: "deny",
+					graphql: {
+						endpoint: "/graphql",
+						allow: { query: ["*"] },
+						unmatched: "prompt",
+					},
+				},
+			},
+		});
+
+		const policies = resolveHostPolicies(config);
+		expect(policies.get("api.github.com")!.graphql!.unmatched).toBe("prompt");
+	});
+
+	it("defaults host unmatched to allow", () => {
+		const config = v.parse(EnclaveFileConfig, {
+			hosts: { "example.com": {} },
+		});
+
+		const policies = resolveHostPolicies(config);
+		expect(policies.get("example.com")!.unmatched).toBe("allow");
+	});
+});
+
+describe("DEFAULT_PACKAGES", () => {
+	it("includes git, curl, jq", () => {
+		expect(DEFAULT_PACKAGES).toContain("git");
+		expect(DEFAULT_PACKAGES).toContain("curl");
+		expect(DEFAULT_PACKAGES).toContain("jq");
+	});
+});

--- a/packages/enclave/test/graphql.test.ts
+++ b/packages/enclave/test/graphql.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { checkGraphQLPolicy, parseGraphQLBody } from "../src/graphql.js";
+
+describe("parseGraphQLBody", () => {
+	it("parses a simple query", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: 'query GetRepo { repository(owner: "x", name: "y") { id } }',
+			}),
+		);
+		expect(ops).toHaveLength(1);
+		expect(ops![0].type).toBe("query");
+		expect(ops![0].name).toBe("GetRepo");
+		expect(ops![0].fields).toEqual(["repository"]);
+	});
+
+	it("parses a mutation with multiple fields", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: `mutation DoStuff {
+				createPullRequest(input: $i) { pullRequest { id } }
+				addComment(input: $c) { comment { id } }
+			}`,
+			}),
+		);
+		expect(ops).toHaveLength(1);
+		expect(ops![0].type).toBe("mutation");
+		expect(ops![0].fields).toEqual(["createPullRequest", "addComment"]);
+	});
+
+	it("parses multiple operations", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: `
+				query ReadStuff { repository { id } }
+				mutation WriteStuff { createIssue(input: $i) { issue { id } } }
+			`,
+			}),
+		);
+		expect(ops).toHaveLength(2);
+		expect(ops![0].type).toBe("query");
+		expect(ops![1].type).toBe("mutation");
+	});
+
+	it("handles anonymous queries", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "{ repository { id } }",
+			}),
+		);
+		expect(ops).toHaveLength(1);
+		expect(ops![0].type).toBe("query");
+		expect(ops![0].name).toBeUndefined();
+	});
+
+	it("returns undefined for invalid JSON", () => {
+		expect(parseGraphQLBody("not json")).toBeUndefined();
+	});
+
+	it("returns undefined for invalid GraphQL", () => {
+		expect(parseGraphQLBody(JSON.stringify({ query: "not graphql {{{}}" }))).toBeUndefined();
+	});
+
+	it("returns undefined when query field is missing", () => {
+		expect(parseGraphQLBody(JSON.stringify({ variables: {} }))).toBeUndefined();
+	});
+});
+
+describe("checkGraphQLPolicy", () => {
+	it("allows all queries with query: ['*']", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "query GetRepo { repository { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: ["*"], mutation: [] });
+		expect(result.allowed).toBe(true);
+	});
+
+	it("allows specific mutation fields", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { createPullRequest(input: $i) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: ["*"], mutation: ["createPullRequest"] });
+		expect(result.allowed).toBe(true);
+	});
+
+	it("denies mutation fields not in the allow list", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { deleteBranchProtectionRule(input: $i) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: ["*"], mutation: ["createPullRequest"] });
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect(result.deniedFields).toEqual(["deleteBranchProtectionRule"]);
+		}
+	});
+
+	it("catches spoofed operation names", () => {
+		// Operation is named CreatePullRequest but actually deletes branch protection
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation CreatePullRequest { deleteBranchProtectionRule(input: $i) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: [], mutation: ["createPullRequest"] });
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect(result.deniedFields).toEqual(["deleteBranchProtectionRule"]);
+		}
+	});
+
+	it("allows all mutations with mutation: ['*']", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { deleteRepository(input: $i) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: [], mutation: ["*"] });
+		expect(result.allowed).toBe(true);
+	});
+
+	it("supports glob patterns", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { createPullRequest(input: $i) { id } createIssue(input: $j) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: [], mutation: ["create*"] });
+		expect(result.allowed).toBe(true);
+	});
+
+	it("denies when no rules match the operation type", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { createIssue(input: $i) { id } }",
+			}),
+		)!;
+		// Only query rules, no mutation rules
+		const result = checkGraphQLPolicy(ops, { query: ["*"], mutation: [] });
+		expect(result.allowed).toBe(false);
+	});
+
+	it("handles mixed allowed and denied fields", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { createPullRequest(input: $i) { id } mergePullRequest(input: $j) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: [], mutation: ["createPullRequest"] });
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect(result.deniedFields).toEqual(["mergePullRequest"]);
+		}
+	});
+
+	it("denies subscription operations (no rules)", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "subscription X { onIssueCreated { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: ["*"], mutation: ["*"] });
+		expect(result.allowed).toBe(false);
+	});
+
+	it("is case-insensitive for field matching", () => {
+		const ops = parseGraphQLBody(
+			JSON.stringify({
+				query: "mutation X { CreatePullRequest(input: $i) { id } }",
+			}),
+		)!;
+		const result = checkGraphQLPolicy(ops, { query: [], mutation: ["createpullrequest"] });
+		expect(result.allowed).toBe(true);
+	});
+});

--- a/packages/enclave/test/integration.test.ts
+++ b/packages/enclave/test/integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for config loading, file creation, and package management.
+ * Uses a temp directory to avoid touching real config files.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	addPackageToConfig,
+	collectConfigFiles,
+	ensureGlobalConfig,
+	globalConfigPath,
+	globalDropInDir,
+	initProjectConfig,
+	loadConfig,
+	mergeConfigs,
+} from "../src/config.js";
+
+// Override HOME so we don't touch real config
+let tmpDir: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+	origHome = process.env.HOME;
+	tmpDir = join(import.meta.dirname ?? ".", `.test-tmp-${Date.now()}`);
+	mkdirSync(tmpDir, { recursive: true });
+	process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+	process.env.HOME = origHome;
+	// Clean up
+	const { rmSync } = require("node:fs");
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("ensureGlobalConfig", () => {
+	it("creates main config and drop-in files", () => {
+		const created = ensureGlobalConfig();
+		expect(created.length).toBeGreaterThan(0);
+		expect(existsSync(globalConfigPath())).toBe(true);
+		expect(existsSync(join(globalDropInDir(), "git.toml"))).toBe(true);
+		expect(existsSync(join(globalDropInDir(), "jj.toml"))).toBe(true);
+		expect(existsSync(join(globalDropInDir(), "github.toml"))).toBe(true);
+	});
+
+	it("does not overwrite existing files", () => {
+		ensureGlobalConfig();
+		// Modify the config
+		const configPath = globalConfigPath();
+		writeFileSync(configPath, 'packages = ["custom"]\n');
+		// Run again
+		const created = ensureGlobalConfig();
+		expect(created).toEqual([]);
+		expect(readFileSync(configPath, "utf-8")).toContain("custom");
+	});
+});
+
+describe("initProjectConfig", () => {
+	it("creates project config from template", () => {
+		const projectDir = join(tmpDir, "project");
+		mkdirSync(projectDir, { recursive: true });
+		const result = initProjectConfig(projectDir);
+		expect(result).toBe(true);
+		const content = readFileSync(join(projectDir, ".pi", "enclave.toml"), "utf-8");
+		expect(content).toContain("enabled = true");
+	});
+
+	it("does not overwrite existing project config", () => {
+		const projectDir = join(tmpDir, "project");
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(projectDir, ".pi", "enclave.toml"), "enabled = false\n");
+		const result = initProjectConfig(projectDir);
+		expect(result).toBe(false);
+	});
+});
+
+describe("collectConfigFiles with drop-ins", () => {
+	it("loads global config and drop-in files", () => {
+		ensureGlobalConfig();
+		const layers = collectConfigFiles(tmpDir);
+		// Global + git.toml + github.toml + jj.toml (alphabetical)
+		expect(layers.length).toBeGreaterThanOrEqual(4);
+		const paths = layers.map((l) => l.path);
+		expect(paths[0]).toBe(globalConfigPath());
+		// Drop-ins are alphabetical
+		expect(paths[1]).toContain("git.toml");
+		expect(paths[2]).toContain("github.toml");
+		expect(paths[3]).toContain("jj.toml");
+	});
+
+	it("merges packages from all layers additively", () => {
+		ensureGlobalConfig();
+		const { merged } = loadConfig(tmpDir);
+		const pkgs = merged.packages ?? [];
+		expect(pkgs).toContain("curl");
+		expect(pkgs).toContain("jq");
+		expect(pkgs).toContain("git");
+		expect(pkgs).toContain("jujutsu");
+		expect(pkgs).toContain("github-cli");
+	});
+
+	it("collects setup scripts from drop-ins", () => {
+		ensureGlobalConfig();
+		const { merged } = loadConfig(tmpDir);
+		expect(merged.setup).toContain("safe.directory");
+		expect(merged.setup).toContain("jj config set");
+	});
+
+	it("reports config sources accurately", () => {
+		ensureGlobalConfig();
+		const projectDir = join(tmpDir, "project");
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(projectDir, ".pi", "enclave.toml"), "enabled = true\n");
+
+		const result = loadConfig(projectDir);
+		expect(result.hasGlobalConfig).toBe(true);
+		expect(result.hasProjectConfig).toBe(true);
+		expect(result.dropIns).toEqual(["git", "github", "jj"]);
+	});
+
+	it("does not walk ancestor directories", () => {
+		ensureGlobalConfig();
+		const parent = join(tmpDir, "parent");
+		const child = join(parent, "child");
+		mkdirSync(join(parent, ".pi"), { recursive: true });
+		mkdirSync(child, { recursive: true });
+		writeFileSync(join(parent, ".pi", "enclave.toml"), "enabled = true\n");
+
+		const result = loadConfig(child);
+		// Parent config should NOT be picked up
+		expect(result.hasProjectConfig).toBe(false);
+		expect(result.merged.enabled).toBeUndefined();
+	});
+});
+
+describe("addPackageToConfig", () => {
+	it("adds a package to an existing config", () => {
+		ensureGlobalConfig();
+		addPackageToConfig(tmpDir, "ripgrep", "global");
+		const content = readFileSync(globalConfigPath(), "utf-8");
+		expect(content).toContain("ripgrep");
+		expect(content).toContain("curl"); // original packages preserved
+	});
+
+	it("does not duplicate existing packages", () => {
+		ensureGlobalConfig();
+		addPackageToConfig(tmpDir, "curl", "global");
+		const content = readFileSync(globalConfigPath(), "utf-8");
+		const matches = content.match(/curl/g);
+		expect(matches).toHaveLength(1);
+	});
+});
+
+describe("mount path ~ expansion", () => {
+	it("expands ~ to HOME in mount paths", () => {
+		ensureGlobalConfig();
+		const projectDir = join(tmpDir, "project");
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(projectDir, ".pi", "enclave.toml"), 'enabled = true\n\n[[mounts]]\npath = "~/dev/.jj"\n');
+		const { merged } = loadConfig(projectDir);
+		expect(merged.mounts?.[0]?.path).toBe(join(tmpDir, "dev/.jj"));
+	});
+});

--- a/packages/enclave/test/policy.test.ts
+++ b/packages/enclave/test/policy.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedHostPolicy } from "../src/config.js";
+import { checkPolicy, evaluateRequest, matchPath } from "../src/policy.js";
+
+describe("matchPath", () => {
+	it("matches literal paths", () => {
+		expect(matchPath("/graphql", "/graphql")).toBe(true);
+		expect(matchPath("/graphql", "/other")).toBe(false);
+	});
+
+	it("matches single-segment wildcard", () => {
+		expect(matchPath("/repos/*/issues", "/repos/owner/issues")).toBe(true);
+		expect(matchPath("/repos/*/issues", "/repos/owner/repo/issues")).toBe(false);
+	});
+
+	it("matches multi-segment wildcard", () => {
+		expect(matchPath("/repos/*/*/pulls", "/repos/owner/repo/pulls")).toBe(true);
+		expect(matchPath("/repos/*/*/pulls", "/repos/owner/pulls")).toBe(false);
+	});
+
+	it("matches ** (rest of path)", () => {
+		expect(matchPath("/repos/**", "/repos/owner/repo/pulls/123")).toBe(true);
+		expect(matchPath("/repos/**", "/repos")).toBe(true);
+		expect(matchPath("/other/**", "/repos/foo")).toBe(false);
+	});
+
+	it("handles * as match-all for single segment", () => {
+		expect(matchPath("*", "/graphql")).toBe(true);
+		expect(matchPath("*", "/repos/foo")).toBe(false);
+	});
+
+	it("/** matches the root path", () => {
+		expect(matchPath("/**", "/")).toBe(true);
+		expect(matchPath("/**", "")).toBe(true);
+	});
+
+	it("normalizes leading slash", () => {
+		expect(matchPath("graphql", "/graphql")).toBe(true);
+		expect(matchPath("/graphql", "graphql")).toBe(true);
+	});
+});
+
+describe("checkPolicy", () => {
+	const policy: ResolvedHostPolicy = {
+		hostname: "api.github.com",
+		allows: new Map([
+			["GET", ["*"]],
+			["POST", ["/repos/*/*/pulls"]],
+		]),
+		deny: ["/repos/*/*/pulls/*/merge", "/repos/*/*/branches/*/protection"],
+		unmatched: "prompt",
+	};
+
+	it("allows matching GET requests", () => {
+		expect(checkPolicy(policy, "GET", "/repos")).toBe("allow");
+		expect(checkPolicy(policy, "GET", "/user")).toBe("allow");
+	});
+
+	it("allows matching POST requests", () => {
+		expect(checkPolicy(policy, "POST", "/repos/owner/repo/pulls")).toBe("allow");
+	});
+
+	it("denies matching deny patterns (overrides allows)", () => {
+		expect(checkPolicy(policy, "POST", "/repos/owner/repo/pulls/1/merge")).toBe("deny");
+		expect(checkPolicy(policy, "GET", "/repos/owner/repo/branches/main/protection")).toBe("deny");
+	});
+
+	it("returns unmatched policy for non-matching requests", () => {
+		expect(checkPolicy(policy, "DELETE", "/repos/owner/repo")).toBe("prompt");
+		expect(checkPolicy(policy, "POST", "/repos/owner/repo/issues")).toBe("prompt");
+	});
+
+	it("is case-insensitive for method", () => {
+		expect(checkPolicy(policy, "get", "/user")).toBe("allow");
+	});
+});
+
+describe("evaluateRequest", () => {
+	it("allows requests when no policy exists for the host", () => {
+		const policies = new Map<string, ResolvedHostPolicy>();
+		expect(evaluateRequest(policies, "example.com", "GET", "/")).toBe("allow");
+	});
+
+	it("checks policy when one exists", () => {
+		const policies = new Map<string, ResolvedHostPolicy>([
+			[
+				"api.github.com",
+				{
+					hostname: "api.github.com",
+					allows: new Map([["GET", ["*"]]]),
+					deny: [],
+					unmatched: "deny",
+				},
+			],
+		]);
+
+		expect(evaluateRequest(policies, "api.github.com", "GET", "/repos")).toBe("allow");
+		expect(evaluateRequest(policies, "api.github.com", "POST", "/repos")).toBe("deny");
+		expect(evaluateRequest(policies, "other.com", "POST", "/anything")).toBe("allow");
+	});
+});

--- a/packages/enclave/test/secrets.test.ts
+++ b/packages/enclave/test/secrets.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEnv, resolveSecrets } from "../src/secrets.js";
+
+// Mock child_process to avoid actually running commands
+vi.mock("node:child_process", () => ({
+	execSync: vi.fn((cmd: string) => {
+		if (cmd === "which gh") return "/usr/bin/gh\n";
+		if (cmd === "gh auth token") return "gho_fake_token_12345\n";
+		if (cmd === "which npm") throw new Error("not found");
+		throw new Error(`command not found: ${cmd}`);
+	}),
+}));
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("resolveSecrets", () => {
+	it("returns empty with no config", () => {
+		const secrets = resolveSecrets({});
+		expect(secrets).toHaveLength(0);
+	});
+
+	it("resolves command-sourced secrets", () => {
+		const secrets = resolveSecrets({
+			GH_TOKEN: { command: "gh auth token", hosts: ["api.github.com"] },
+		});
+		expect(secrets).toHaveLength(1);
+		expect(secrets[0].name).toBe("GH_TOKEN");
+		expect(secrets[0].value).toBe("gho_fake_token_12345");
+		expect(secrets[0].hosts).toEqual(["api.github.com"]);
+	});
+
+	it("skips command secrets when binary is not found", () => {
+		const secrets = resolveSecrets({
+			NPM_TOKEN: { command: "npm config get token", hosts: ["registry.npmjs.org"] },
+		});
+		expect(secrets).toHaveLength(0);
+	});
+
+	it("resolves env-sourced secrets", () => {
+		process.env.TEST_SECRET = "secret_value";
+		try {
+			const secrets = resolveSecrets({
+				TEST_SECRET: { env: "TEST_SECRET", hosts: ["api.example.com"] },
+			});
+			expect(secrets).toHaveLength(1);
+			expect(secrets[0].value).toBe("secret_value");
+			expect(secrets[0].hosts).toEqual(["api.example.com"]);
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env needs delete to truly unset
+			delete process.env.TEST_SECRET;
+		}
+	});
+
+	it("skips env secrets when env var is not set", () => {
+		// biome-ignore lint/performance/noDelete: process.env needs delete to truly unset
+		delete process.env.MISSING_VAR;
+		const secrets = resolveSecrets({
+			MISSING: { env: "MISSING_VAR", hosts: ["example.com"] },
+		});
+		expect(secrets).toHaveLength(0);
+	});
+
+	it("skips false entries", () => {
+		const secrets = resolveSecrets({
+			GH_TOKEN: false,
+		});
+		expect(secrets).toHaveLength(0);
+	});
+
+	it("resolves multiple secrets", () => {
+		process.env.OPENAI_KEY = "sk-test";
+		try {
+			const secrets = resolveSecrets({
+				GH_TOKEN: { command: "gh auth token", hosts: ["api.github.com"] },
+				OPENAI_KEY: { env: "OPENAI_KEY", hosts: ["api.openai.com"] },
+			});
+			expect(secrets).toHaveLength(2);
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env needs delete to truly unset
+			delete process.env.OPENAI_KEY;
+		}
+	});
+});
+
+describe("resolveEnv", () => {
+	it("resolves static string values", () => {
+		const env = resolveEnv({ EDITOR: "vim", LANG: "en_US.UTF-8" });
+		expect(env).toEqual({ EDITOR: "vim", LANG: "en_US.UTF-8" });
+	});
+
+	it("resolves command sources", () => {
+		const env = resolveEnv({ USER_NAME: { command: "gh auth token" } });
+		expect(env.USER_NAME).toBe("gho_fake_token_12345");
+	});
+
+	it("skips command sources when binary is missing", () => {
+		const env = resolveEnv({ TOKEN: { command: "npm config get token" } });
+		expect(env.TOKEN).toBeUndefined();
+	});
+
+	it("resolves env sources", () => {
+		process.env.TEST_VAR = "hello";
+		try {
+			const env = resolveEnv({ GREETING: { env: "TEST_VAR" } });
+			expect(env.GREETING).toBe("hello");
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env needs delete to truly unset
+			delete process.env.TEST_VAR;
+		}
+	});
+
+	it("skips missing env sources", () => {
+		const env = resolveEnv({ MISSING: { env: "NONEXISTENT_VAR" } });
+		expect(env.MISSING).toBeUndefined();
+	});
+});

--- a/packages/enclave/tsconfig.json
+++ b/packages/enclave/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/enclave/tsup.config.ts
+++ b/packages/enclave/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	external: ["@mariozechner/pi-coding-agent", "@earendil-works/gondolin"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,6 +931,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@earendil-works/gondolin@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@earendil-works/gondolin@npm:0.6.0"
+  dependencies:
+    cbor: "npm:^10.0.4"
+    node-forge: "npm:^1.3.3"
+    ssh2: "npm:^1.17.0"
+    undici: "npm:^6.21.0"
+  bin:
+    gondolin: dist/bin/gondolin.js
+  checksum: 10c0/b54f62239f9b2cb7fe342afe31ae2a65cfddb58b0b500de2a9172c64384d99104e9904fa322bcda6cd17d71b94973ff12e74bdd90df05233d63efeed2089642e
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/aix-ppc64@npm:0.27.3"
@@ -2599,6 +2613,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "asn1@npm:0.2.6"
+  dependencies:
+    safer-buffer: "npm:~2.1.0"
+  checksum: 10c0/00c8a06c37e548762306bcb1488388d2f76c74c36f70c803f0c081a01d3bdf26090fc088cd812afc5e56a6d49e33765d451a5f8a68ab9c2b087eba65d2e980e0
+  languageName: node
+  linkType: hard
+
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -2640,6 +2663,15 @@ __metadata:
   version: 5.2.0
   resolution: "basic-ftp@npm:5.2.0"
   checksum: 10c0/a0f85c01deae0723021f9bf4a7be29378186fa8bba41e74ea11832fe74c187ce90c3599c3cc5ec936581cfd150020e79f4a9ed0ee9fb20b2308e69b045f3a059
+  languageName: node
+  linkType: hard
+
+"bcrypt-pbkdf@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "bcrypt-pbkdf@npm:1.0.2"
+  dependencies:
+    tweetnacl: "npm:^0.14.3"
+  checksum: 10c0/ddfe85230b32df25aeebfdccfbc61d3bc493ace49c884c9c68575de1f5dcf733a5d7de9def3b0f318b786616b8d85bad50a28b1da1750c43e0012c93badcc148
   languageName: node
   linkType: hard
 
@@ -2707,6 +2739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buildcheck@npm:~0.0.6":
+  version: 0.0.7
+  resolution: "buildcheck@npm:0.0.7"
+  checksum: 10c0/987c605267b1b6311bb2ac0638b073d322370267445a6d059da27985fce0b41f85a59d3a9aa9af839e8ac2d63da8af07be6dc737f8bd5323e1dfe6779ad67228
+  languageName: node
+  linkType: hard
+
 "bundle-require@npm:^5.1.0":
   version: 5.1.0
   resolution: "bundle-require@npm:5.1.0"
@@ -2741,6 +2780,15 @@ __metadata:
     ssri: "npm:^13.0.0"
     unique-filename: "npm:^5.0.0"
   checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
+  languageName: node
+  linkType: hard
+
+"cbor@npm:^10.0.4":
+  version: 10.0.12
+  resolution: "cbor@npm:10.0.12"
+  dependencies:
+    nofilter: "npm:^3.0.2"
+  checksum: 10c0/4c197d783415cade31565725a5e6b2b967d856285eacdb0b5f5ec0687d93c12f2ee9c6cc05aa7be02e8bbf0fe3ba40d22be69b56bd2ab1be2cc0a59370f14246
   languageName: node
   linkType: hard
 
@@ -2865,6 +2913,17 @@ __metadata:
   version: 3.4.2
   resolution: "consola@npm:3.4.2"
   checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
+  languageName: node
+  linkType: hard
+
+"cpu-features@npm:~0.0.10":
+  version: 0.0.10
+  resolution: "cpu-features@npm:0.0.10"
+  dependencies:
+    buildcheck: "npm:~0.0.6"
+    nan: "npm:^2.19.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/0c4a12904657b22477ffbcfd2b4b2bdd45b174f283616b18d9e1ade495083f9f6098493feb09f4ae2d0b36b240f9ecd32cfb4afe210cf0d0f8f0cc257bd58e54
   languageName: node
   linkType: hard
 
@@ -3551,6 +3610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql@npm:^16.13.1":
+  version: 16.13.1
+  resolution: "graphql@npm:16.13.1"
+  checksum: 10c0/0c7a9aea59504fbf3e0674f13ddb82935780f2a388e1db0ef41c3711c0ff8cb0a871c50d30d2d5288f32b946af3570d6f9ba8d13b03a330336f27121f9ac7a6b
+  languageName: node
+  linkType: hard
+
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
@@ -4103,6 +4169,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.19.0, nan@npm:^2.23.0":
+  version: 2.26.2
+  resolution: "nan@npm:2.26.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/ff204c964729279cf3abb8b170c77753ed36092e2235f11bfb0204dfd3e8cc2d5a3bcfdfd3b677f06a0743d7f835d873dce59f23a2dbf6fb671d9351cc655d73
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
@@ -4144,6 +4219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-forge@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10c0/9c6f53b0ebb34865872cf62a35b0aef8fb337e2efc766626c2e3a0040f4c02933bf29a62ba999eb44a2aca73bd512c4eda22705a47b94654b9fb8ed53db9a1db
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 12.2.0
   resolution: "node-gyp@npm:12.2.0"
@@ -4161,6 +4243,13 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10c0/3ed046746a5a7d90950cd8b0547332b06598443f31fe213ef4332a7174c7b7d259e1704835feda79b87d3f02e59d7791842aac60642ede4396ab25fdf0f8f759
+  languageName: node
+  linkType: hard
+
+"nofilter@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "nofilter@npm:3.1.0"
+  checksum: 10c0/92459f3864a067b347032263f0b536223cbfc98153913b5dce350cb39c8470bc1813366e41993f22c33cc6400c0f392aa324a4b51e24c22040635c1cdb046499
   languageName: node
   linkType: hard
 
@@ -4451,6 +4540,23 @@ __metadata:
   peerDependenciesMeta:
     "@mariozechner/pi-coding-agent":
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"pi-enclave@workspace:packages/enclave":
+  version: 0.0.0-use.local
+  resolution: "pi-enclave@workspace:packages/enclave"
+  dependencies:
+    "@earendil-works/gondolin": "npm:^0.6.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@types/node": "npm:^25.3.5"
+    graphql: "npm:^16.13.1"
+    smol-toml: "npm:^1.6.0"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^5.9.3"
+    valibot: "npm:^1.2.0"
+  peerDependencies:
+    "@mariozechner/pi-coding-agent": "*"
   languageName: unknown
   linkType: soft
 
@@ -4854,7 +4960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -4921,6 +5027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smol-toml@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "smol-toml@npm:1.6.0"
+  checksum: 10c0/baf33bb6cd914d481329e31998a12829cd126541458ba400791212c80f1245d5b27dac04a56a52c02b287d2a494f1628c05fc19643286b258b2e0bb9fe67747c
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -4977,6 +5090,23 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
+  languageName: node
+  linkType: hard
+
+"ssh2@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "ssh2@npm:1.17.0"
+  dependencies:
+    asn1: "npm:^0.2.6"
+    bcrypt-pbkdf: "npm:^1.0.2"
+    cpu-features: "npm:~0.0.10"
+    nan: "npm:^2.23.0"
+  dependenciesMeta:
+    cpu-features:
+      optional: true
+    nan:
+      optional: true
+  checksum: 10c0/637c1b7e8070fc8a3027f8abf771cd98419f56eaf3817171180e768004d4dea26c65fb3763294ed2f784429857f196c83c4f6889d2c31cc0e2648ea5ad730665
   languageName: node
   linkType: hard
 
@@ -5277,6 +5407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tweetnacl@npm:^0.14.3":
+  version: 0.14.5
+  resolution: "tweetnacl@npm:0.14.5"
+  checksum: 10c0/4612772653512c7bc19e61923fbf42903f5e0389ec76a4a1f17195859d114671ea4aa3b734c2029ce7e1fa7e5cc8b80580f67b071ecf0b46b5636d030a0102a2
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
@@ -5315,6 +5452,13 @@ __metadata:
   version: 7.18.2
   resolution: "undici-types@npm:7.18.2"
   checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.21.0":
+  version: 6.24.1
+  resolution: "undici@npm:6.24.1"
+  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## pi-enclave

VM-isolated enclave for pi. Runs all tools (bash, read, write, edit) inside a [Gondolin](https://github.com/earendel-works/gondolin) micro-VM so secrets never enter the agent's execution environment.

### How it works

Tools execute inside an Alpine Linux micro-VM (QEMU/aarch64). The workspace is mounted read-write at the same path. Secrets are resolved on the host and injected via HTTP proxy with placeholder substitution; the VM never sees real credential values.

### Features

- **VM isolation**: All pi tools execute inside the micro-VM
- **Secret protection**: Config-driven secrets (command/env sources), injected via HTTP proxy
- **Modular drop-in config**: `pi-enclave.d/` directory with self-contained `.toml` files (git, jj, GitHub ship by default)
- **Generic env vars**: `[env]` section injects host values (static, command, env var) into the VM
- **Setup scripts**: Raw shell per drop-in, run after package install
- **Per-host HTTP policies**: Method+path allow/deny with `prompt` for unmatched requests
- **GraphQL-aware policy**: Parses request bodies, checks actual field names (not spoofable operation names)
- **Git credential helpers**: `[[git-credentials]]` for explicit HTTPS auth using secret placeholders
- **Extra mounts**: `[[mounts]]` for jj workspaces or shared directories
- **`/enclave` command**: status, init, on/off, restart, add (with interactive Alpine package search)
- **Eager VM startup**: Boots on session start, ready before first tool call

### Configuration

Two locations: global (`~/.pi/agent/extensions/pi-enclave.toml` + drop-ins) and project (`.pi/enclave.toml`). Packages accumulate across layers; secrets, hosts, and env merge by key.

### Structure

| File | Purpose |
|------|---------|
| `config.ts` | TOML schema, global + project config resolution, drop-in loading |
| `secrets.ts` | Secret and env var resolution (command/env sources) |
| `graphql.ts` | AST-based GraphQL policy enforcement |
| `policy.ts` | HTTP method+path policy matching with globs |
| `vm.ts` | Gondolin VM lifecycle, VFS + HTTP hooks, setup scripts |
| `tools.ts` | VM-backed tool operations (read/write/edit/bash) |
| `index.ts` | Extension entry: wires everything together |

### Tests

362 tests: config schema and merging, GraphQL parsing and policy, HTTP policy matching, secret and env resolution, integration tests (config lifecycle, drop-in loading, package management).

### Requirements

QEMU: `brew install qemu` (macOS) or `sudo apt install qemu-system-aarch64` (Linux)