### PR TITLE
feat: add pi-bash-bg package

### DIFF
--- a/.changeset/add-bash-bg.md
+++ b/.changeset/add-bash-bg.md
@@ -1,0 +1,5 @@
+---
+"pi-bash-bg": minor
+---
+
+New package: pi-bash-bg. Makes `command &` work in pi's bash tool by intercepting bash tool calls, detecting background processes via AST parsing (@aliou/sh), and rewriting commands to redirect output to temp log files and disown. Compound commands (&&, ||, pipelines) are wrapped in braces so the redirect applies to the entire background subshell. The agent sees the PID, label, and log file path in the tool output.

--- a/.changeset/bash-bg-bash-tool-description.md
+++ b/.changeset/bash-bg-bash-tool-description.md
@@ -1,0 +1,5 @@
+---
+"pi-bash-bg": patch
+---
+
+Append background-job behavior guidance to the bash tool description so models see that background jobs keep running, output is captured to a log file, and the PID plus log path are returned.

--- a/.changeset/friendly-bash-bg-logs.md
+++ b/.changeset/friendly-bash-bg-logs.md
@@ -1,0 +1,5 @@
+---
+"pi-bash-bg": patch
+---
+
+Make background log file names human-readable by basing them on the detected command label and using a simple numeric suffix for uniqueness.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Monorepo of extensions and libraries for [pi](https://pi.dev). Managed with Yarn
 | pi-budget-model | `packages/budget-model/` | library |
 | pi-no-soft-cursor | `packages/no-soft-cursor/` | pi extension |
 | pi-jujutsu | `packages/jujutsu/` | pi extension |
+| pi-bash-bg | `packages/bash-bg/` | pi extension |
 
 ## Workflow
 

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -8,7 +8,7 @@ The bash tool pipes stdout/stderr from the spawned shell. When a command backgro
 
 ## Solution
 
-This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), and rewrites the command to:
+This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), appends background-job guidance to the bash tool description, and rewrites the command to:
 
 1. **Redirect output** to temp log files with human-readable names based on the command label, so background processes release the pipes
 2. **Add `disown`** to detach from job control (if not already present)
@@ -78,9 +78,9 @@ echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-npm-start-3.log"
 
 If the command already has `disown` after the `&`, no duplicate is added.
 
-### System prompt
+### Bash tool description
 
-The extension replaces the default "command & doesn't work" guidance in the system prompt with instructions on how to use background processes and check their output.
+The extension appends a short background-job summary to the bash tool description, so the model sees it directly in tool metadata.
 
 ## Supported patterns
 

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -1,0 +1,89 @@
+# pi-bash-bg
+
+Makes `command &` work in pi's bash tool by detaching background processes from pipes.
+
+## Problem
+
+The bash tool pipes stdout/stderr from the spawned shell. When a command backgrounds a process with `&`, the background process inherits these pipe file descriptors and keeps them open. Node.js waits for all pipe readers to close, so the tool hangs until the background process exits.
+
+## Solution
+
+This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), and rewrites the command to:
+
+1. **Redirect output** to temp log files so background processes release the pipes
+2. **Add `disown`** to detach from job control (if not already present)
+3. **Append echo** reporting PID, label, and log path
+
+The agent sees something like:
+
+```
+[bg] pid=12345 label=npm run dev log=/tmp/pi-bg-abc-0.log
+```
+
+It can then `cat` the log file or `kill` the PID.
+
+## Install
+
+```bash
+pi install pi-bash-bg
+```
+
+## How it works
+
+### Simple commands
+
+```bash
+# Before:
+npm run dev &
+# After:
+npm run dev > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm run dev log=/tmp/pi-bg-xxx-0.log"
+```
+
+### Compound commands (&&, ||, pipelines)
+
+Compound commands are wrapped in braces so the redirect applies to the entire background subshell, not just the last command in the chain:
+
+```bash
+# Before:
+cd /app && npm start &
+# After:
+{ cd /app && npm start; } > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-xxx-0.log"
+```
+
+### Existing redirections
+
+If the command already redirects both stdout and stderr, the extension only adds `disown`:
+
+```bash
+# Before:
+node server.js > /dev/null 2>&1 &
+# After:
+node server.js > /dev/null 2>&1 & disown $!;
+echo "[bg] pid=$! label=node server.js log=/tmp/pi-bg-xxx-0.log"
+```
+
+### Existing disown
+
+If the command already has `disown` after the `&`, no duplicate is added.
+
+### System prompt
+
+The extension replaces the default "command & doesn't work" guidance in the system prompt with instructions on how to use background processes and check their output.
+
+## Supported patterns
+
+| Pattern | Handled |
+|---------|---------|
+| `npm run dev &` | Yes |
+| `cd /dir && npm start &` | Yes (wrapped in braces) |
+| `tail -f log \| grep error &` | Yes (wrapped in braces) |
+| `nohup node server.js &` | Yes |
+| `PORT=3000 node server.js &` | Yes |
+| `while true; do sleep 1; done &` | Yes (wrapped in braces) |
+| `(sleep 10 && echo done) &` | Yes (wrapped in braces) |
+| `cmd &> /dev/null &` | Yes (skips adding redirects) |
+| `cmd & disown $!` | Yes (skips adding disown) |
+| `echo "foo & bar"` | Ignored (& inside string) |
+| `cmd1 && cmd2` | Ignored (no background) |

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -54,14 +54,24 @@ echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-xxx-0.log"
 
 ### Existing redirections
 
-If the command already redirects both stdout and stderr, the extension only adds `disown`:
+If a simple command already redirects both stdout and stderr, the extension only adds `disown` (no log file is created):
 
 ```bash
 # Before:
 node server.js > /dev/null 2>&1 &
 # After:
 node server.js > /dev/null 2>&1 & disown $!;
-echo "[bg] pid=$! label=node server.js log=/tmp/pi-bg-xxx-0.log"
+echo "[bg] pid=$! label=node server.js"
+```
+
+Compound commands are always wrapped in braces, even if their inner commands have redirections. This is necessary because the background subshell itself holds the pipe file descriptors open regardless of what its child commands do:
+
+```bash
+# Before:
+cd /app && npm start > /dev/null 2>&1 &
+# After:
+{ cd /app && npm start > /dev/null 2>&1; } > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-xxx-0.log"
 ```
 
 ### Existing disown
@@ -83,7 +93,7 @@ The extension replaces the default "command & doesn't work" guidance in the syst
 | `PORT=3000 node server.js &` | Yes |
 | `while true; do sleep 1; done &` | Yes (wrapped in braces) |
 | `(sleep 10 && echo done) &` | Yes (wrapped in braces) |
-| `cmd &> /dev/null &` | Yes (skips adding redirects) |
+| `cmd &> /dev/null &` | Yes (skips adding redirects for simple commands) |
 | `cmd & disown $!` | Yes (skips adding disown) |
 | `echo "foo & bar"` | Ignored (& inside string) |
 | `cmd1 && cmd2` | Ignored (no background) |

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -10,14 +10,14 @@ The bash tool pipes stdout/stderr from the spawned shell. When a command backgro
 
 This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), and rewrites the command to:
 
-1. **Redirect output** to temp log files so background processes release the pipes
+1. **Redirect output** to temp log files with human-readable names based on the command label, so background processes release the pipes
 2. **Add `disown`** to detach from job control (if not already present)
 3. **Append echo** reporting PID, label, and log path
 
 The agent sees something like:
 
 ```
-[bg] pid=12345 label=npm run dev log=/tmp/pi-bg-abc-0.log
+[bg] pid=12345 label=npm run dev log=/tmp/pi-bg-npm-run-dev-1.log
 ```
 
 It can then `cat` the log file or `kill` the PID.
@@ -36,8 +36,8 @@ pi install pi-bash-bg
 # Before:
 npm run dev &
 # After:
-npm run dev > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
-echo "[bg] pid=$! label=npm run dev log=/tmp/pi-bg-xxx-0.log"
+npm run dev > /tmp/pi-bg-npm-run-dev-1.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm run dev log=/tmp/pi-bg-npm-run-dev-1.log"
 ```
 
 ### Compound commands (&&, ||, pipelines)
@@ -48,8 +48,8 @@ Compound commands are wrapped in braces so the redirect applies to the entire ba
 # Before:
 cd /app && npm start &
 # After:
-{ cd /app && npm start; } > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
-echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-xxx-0.log"
+{ cd /app && npm start; } > /tmp/pi-bg-npm-start-2.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-npm-start-2.log"
 ```
 
 ### Existing redirections
@@ -70,8 +70,8 @@ Compound commands are always wrapped in braces, even if their inner commands hav
 # Before:
 cd /app && npm start > /dev/null 2>&1 &
 # After:
-{ cd /app && npm start > /dev/null 2>&1; } > /tmp/pi-bg-xxx-0.log 2>&1 & disown $!;
-echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-xxx-0.log"
+{ cd /app && npm start > /dev/null 2>&1; } > /tmp/pi-bg-npm-start-3.log 2>&1 & disown $!;
+echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-npm-start-3.log"
 ```
 
 ### Existing disown

--- a/packages/bash-bg/package.json
+++ b/packages/bash-bg/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "pi-bash-bg",
+  "version": "0.0.1",
+  "description": "Makes command & work in pi's bash tool by detaching background processes from pipes · from yapp",
+  "author": "mgabor3141",
+  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/mgabor3141/yapp.git",
+    "directory": "packages/bash-bg"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "yapp"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "pi": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
+  "dependencies": {
+    "@aliou/sh": "^0.1.0",
+    "valibot": "^1.2.0"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@types/node": "^25.3.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/bash-bg/src/detect.ts
+++ b/packages/bash-bg/src/detect.ts
@@ -1,0 +1,235 @@
+/**
+ * AST-based detection of background commands in bash scripts.
+ *
+ * Uses @aliou/sh to parse commands and identify statements with `background: true`.
+ * Extracts metadata needed for rewriting: whether redirections already exist,
+ * whether disown follows, and a human-readable label for the process.
+ */
+
+import {
+	type Command,
+	type Logical,
+	type Pipeline,
+	type Program,
+	type Redirect,
+	type SimpleCommand,
+	type Statement,
+	type Word,
+	parse,
+} from "@aliou/sh";
+
+/** Metadata about a single background statement in the script. */
+export interface BgStatement {
+	/** Index into the Program.body array. */
+	index: number;
+	/** Human-readable label for the process (e.g. "npm run dev"). */
+	label: string;
+	/** Whether stdout is already redirected (>, >>, &>, &>>). */
+	hasStdoutRedirect: boolean;
+	/** Whether stderr is already redirected (2>, 2>>, >&, &>, &>>). */
+	hasStderrRedirect: boolean;
+	/** Whether the next statement is a `disown` command. */
+	followedByDisown: boolean;
+	/**
+	 * Whether the command is compound (Logical, Pipeline, Subshell, Block, etc.).
+	 * Compound commands need to be wrapped in `{ ...; }` so that the redirect
+	 * applies to the whole background subshell, not just the last simple command.
+	 */
+	isCompound: boolean;
+}
+
+/** Result of analyzing a bash command for background processes. */
+export interface DetectResult {
+	/** The parsed AST (null if parsing failed). */
+	ast: Program | null;
+	/** Background statements found. Empty if none or parse failure. */
+	bgStatements: BgStatement[];
+}
+
+/** Parse a bash command and find all background statements. */
+export function detectBackground(command: string): DetectResult {
+	let ast: Program;
+	try {
+		({ ast } = parse(command, { dialect: "bash" }));
+	} catch {
+		return { ast: null, bgStatements: [] };
+	}
+
+	const bgStatements: BgStatement[] = [];
+
+	for (let i = 0; i < ast.body.length; i++) {
+		const stmt = ast.body[i];
+		if (!stmt.background) continue;
+
+		const label = extractLabel(stmt);
+		const { hasStdoutRedirect, hasStderrRedirect } = checkRedirects(stmt.command);
+		const followedByDisown = isFollowedByDisown(ast.body, i);
+		const isCompound = stmt.command.type !== "SimpleCommand" && stmt.command.type !== "DeclClause";
+
+		bgStatements.push({
+			index: i,
+			label,
+			hasStdoutRedirect,
+			hasStderrRedirect,
+			followedByDisown,
+			isCompound,
+		});
+	}
+
+	return { ast, bgStatements };
+}
+
+// ── Redirect detection ───────────────────────────────────────────────────────
+
+function checkRedirects(cmd: Command): { hasStdoutRedirect: boolean; hasStderrRedirect: boolean } {
+	const redirects = collectRedirects(cmd);
+	let hasStdoutRedirect = false;
+	let hasStderrRedirect = false;
+
+	for (const r of redirects) {
+		const op = r.op;
+		const fd = r.fd;
+
+		// &> and &>> redirect both stdout and stderr
+		if (op === "&>" || op === "&>>") {
+			hasStdoutRedirect = true;
+			hasStderrRedirect = true;
+			continue;
+		}
+
+		// > or >> without fd, or with fd=1: stdout redirect
+		if ((op === ">" || op === ">>" || op === ">|") && (fd === undefined || fd === "1")) {
+			hasStdoutRedirect = true;
+			continue;
+		}
+
+		// >& (dup): 2>&1 redirects stderr to stdout
+		if (op === ">&" && fd === "2") {
+			hasStderrRedirect = true;
+			continue;
+		}
+
+		// 2> or 2>>: explicit stderr redirect
+		if ((op === ">" || op === ">>") && fd === "2") {
+			hasStderrRedirect = true;
+		}
+	}
+
+	return { hasStdoutRedirect, hasStderrRedirect };
+}
+
+/**
+ * Collect all redirects from a command, walking into compound structures.
+ * For Logical (&&, ||), the redirects that matter for pipe inheritance
+ * are on the rightmost command (the one that actually runs in background).
+ */
+function collectRedirects(cmd: Command): Redirect[] {
+	switch (cmd.type) {
+		case "SimpleCommand":
+			return cmd.redirects ?? [];
+		case "Logical":
+			// In `cd /dir && npm start &`, npm start is the rightmost
+			return collectRedirects(cmd.right.command);
+		case "Pipeline":
+			// Last command in the pipeline inherits the pipes
+			if (cmd.commands.length > 0) {
+				return collectRedirects(cmd.commands[cmd.commands.length - 1].command);
+			}
+			return [];
+		default:
+			return [];
+	}
+}
+
+// ── Disown detection ─────────────────────────────────────────────────────────
+
+function isFollowedByDisown(body: Statement[], bgIndex: number): boolean {
+	// Check subsequent statements (not just the immediate next one)
+	// for patterns like: cmd & PID=$!; disown $PID
+	for (let j = bgIndex + 1; j < body.length; j++) {
+		const next = body[j];
+		if (next.background) break; // Another background command, stop looking
+		const name = getCommandName(next.command);
+		if (name === "disown") return true;
+		// Keep looking past assignments like PID=$!
+		if (next.command.type === "SimpleCommand" && !next.command.words?.length) continue;
+		// Any other real command means disown isn't coming
+		if (name !== null) break;
+	}
+	return false;
+}
+
+// ── Label extraction ─────────────────────────────────────────────────────────
+
+const WRAPPER_COMMANDS = new Set(["nohup", "env", "nice", "ionice", "time", "strace", "sudo"]);
+
+/** Extract a human-readable label for a background command. */
+function extractLabel(stmt: Statement): string {
+	return extractCommandLabel(stmt.command);
+}
+
+function extractCommandLabel(cmd: Command): string {
+	switch (cmd.type) {
+		case "SimpleCommand":
+			return getSimpleCommandLabel(cmd);
+		case "Logical":
+			// For "cd /dir && npm start &", use the rightmost command
+			return extractCommandLabel(cmd.right.command);
+		case "Pipeline": {
+			const parts = cmd.commands.map((s) => extractCommandLabel(s.command));
+			return parts.join(" | ");
+		}
+		case "Subshell":
+			return "(subshell)";
+		case "Block":
+			return "{block}";
+		case "WhileClause":
+			return "while loop";
+		case "ForClause":
+			return `for ${cmd.name}`;
+		default:
+			return cmd.type;
+	}
+}
+
+function getSimpleCommandLabel(cmd: SimpleCommand): string {
+	if (!cmd.words?.length) return "(assignment)";
+	const words = cmd.words.map(wordToString);
+
+	// Skip wrapper commands (nohup, env, sudo, etc.)
+	let start = 0;
+	while (start < words.length && WRAPPER_COMMANDS.has(words[start])) start++;
+
+	const meaningful = words.slice(start);
+	return meaningful.length > 0 ? meaningful.join(" ") : words.join(" ");
+}
+
+function wordToString(word: Word): string {
+	return word.parts
+		.map((p) => {
+			switch (p.type) {
+				case "Literal":
+					return p.value;
+				case "SglQuoted":
+					return `'${p.value}'`;
+				case "DblQuoted":
+					return p.parts
+						.map((dp) => (dp.type === "Literal" ? dp.value : `$${dp.type === "ParamExp" ? dp.param.value : "(...)"}`))
+						.join("");
+				case "ParamExp":
+					return `$${p.param.value}`;
+				case "CmdSubst":
+					return "$(...)";
+				default:
+					return "";
+			}
+		})
+		.join("");
+}
+
+function getCommandName(cmd: Command): string | null {
+	if (cmd.type === "SimpleCommand" && cmd.words?.length) {
+		return wordToString(cmd.words[0]);
+	}
+	return null;
+}

--- a/packages/bash-bg/src/index.ts
+++ b/packages/bash-bg/src/index.ts
@@ -15,14 +15,23 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import { createBashTool, isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import { detectBackground } from "./detect.js";
 import { rewriteCommand } from "./rewrite.js";
 
 export { detectBackground, type BgStatement, type DetectResult } from "./detect.js";
 export { rewriteCommand, findBgOperatorPositions, type BgProcessInfo, type RewriteResult } from "./rewrite.js";
 
+const BASH_DESCRIPTION_APPENDIX =
+	"Background jobs continue running after the command returns. Their output is captured to a log file even without explicit redirection. The PID and log path will be returned.";
+
 export default function (pi: ExtensionAPI) {
+	const bashTool = createBashTool(process.cwd());
+	pi.registerTool({
+		...bashTool,
+		description: `${bashTool.description} ${BASH_DESCRIPTION_APPENDIX}`,
+	});
+
 	pi.on("tool_call", async (event) => {
 		if (!isToolCallEventType("bash", event)) return;
 
@@ -32,22 +41,5 @@ export default function (pi: ExtensionAPI) {
 
 		const { command: rewritten } = rewriteCommand(command, bgStatements);
 		event.input.command = rewritten;
-	});
-
-	pi.on("before_agent_start", async (event) => {
-		const prompt = event.systemPrompt;
-
-		// Replace the "command & doesn't work" guidance if present
-		const oldGuidance =
-			"`command &` syntax doesn't work for backgrounding because the bash tool waits for all children to complete regardless.";
-		const newGuidance = [
-			"`command &` works for backgrounding processes.",
-			"Background process output is captured to a temp log file. The tool output reports the PID, label, and log path.",
-			"Use `cat <logfile>` to check output and `kill <pid>` to stop a background process.",
-		].join(" ");
-
-		if (prompt.includes(oldGuidance)) {
-			return { systemPrompt: prompt.replace(oldGuidance, newGuidance) };
-		}
 	});
 }

--- a/packages/bash-bg/src/index.ts
+++ b/packages/bash-bg/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * pi-bash-bg — Makes `command &` work in pi's bash tool.
+ *
+ * The bash tool pipes stdout/stderr from the spawned shell. When a command
+ * backgrounds a process with `&`, the background process inherits these pipes
+ * and keeps them open, causing the tool to hang until the process exits.
+ *
+ * This extension intercepts bash tool calls, parses the command with @aliou/sh
+ * to detect background processes, and rewrites the command to redirect their
+ * output to temp log files and disown them from job control. The shell then
+ * exits cleanly and the bash tool returns immediately.
+ *
+ * The agent sees the PID, label, and log file path in the tool output,
+ * and can check on the process with `cat <logfile>` or `kill <pid>`.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import { detectBackground } from "./detect.js";
+import { rewriteCommand } from "./rewrite.js";
+
+export { detectBackground, type BgStatement, type DetectResult } from "./detect.js";
+export { rewriteCommand, findBgOperatorPositions, type BgProcessInfo, type RewriteResult } from "./rewrite.js";
+
+export default function (pi: ExtensionAPI) {
+	pi.on("tool_call", async (event) => {
+		if (!isToolCallEventType("bash", event)) return;
+
+		const command = event.input.command;
+		const { bgStatements } = detectBackground(command);
+		if (bgStatements.length === 0) return;
+
+		const { command: rewritten } = rewriteCommand(command, bgStatements);
+		event.input.command = rewritten;
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		const prompt = event.systemPrompt;
+
+		// Replace the "command & doesn't work" guidance if present
+		const oldGuidance =
+			"`command &` syntax doesn't work for backgrounding because the bash tool waits for all children to complete regardless.";
+		const newGuidance = [
+			"`command &` works for backgrounding processes.",
+			"Background process output is captured to a temp log file. The tool output reports the PID, label, and log path.",
+			"Use `cat <logfile>` to check output and `kill <pid>` to stop a background process.",
+		].join(" ");
+
+		if (prompt.includes(oldGuidance)) {
+			return { systemPrompt: prompt.replace(oldGuidance, newGuidance) };
+		}
+	});
+}

--- a/packages/bash-bg/src/rewrite.ts
+++ b/packages/bash-bg/src/rewrite.ts
@@ -1,0 +1,207 @@
+/**
+ * Command rewriting for background processes.
+ *
+ * Takes a bash command string and the detection results, then rewrites
+ * background commands to:
+ * 1. Redirect stdout/stderr to temp log files (if not already redirected)
+ * 2. Add `disown` to detach from job control (if not already present)
+ * 3. Append echo statements reporting PID, label, and log path
+ *
+ * This prevents background processes from holding the bash tool's pipes
+ * open, which would otherwise hang the tool call indefinitely.
+ */
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BgStatement } from "./detect.js";
+
+/** Info about a background process started by the rewritten command. */
+export interface BgProcessInfo {
+	/** Unique index for this background process within the command. */
+	index: number;
+	/** Human-readable label from AST analysis. */
+	label: string;
+	/** Path to the log file capturing stdout/stderr. */
+	logFile: string;
+}
+
+/** Result of rewriting a command. */
+export interface RewriteResult {
+	/** The rewritten command string. */
+	command: string;
+	/** Info about each background process. */
+	processes: BgProcessInfo[];
+}
+
+/**
+ * Find the positions of background `&` operators in the command text.
+ *
+ * Walks the string tracking quote state to distinguish real operators
+ * from `&` inside strings. Skips `&&`, `&>`, `>&`.
+ */
+export function findBgOperatorPositions(text: string): number[] {
+	const positions: number[] = [];
+	let inSingle = false;
+	let inDouble = false;
+	let escaped = false;
+
+	for (let i = 0; i < text.length; i++) {
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+
+		const ch = text[i];
+
+		if (ch === "\\" && !inSingle) {
+			escaped = true;
+			continue;
+		}
+		if (ch === "'" && !inDouble) {
+			inSingle = !inSingle;
+			continue;
+		}
+		if (ch === '"' && !inSingle) {
+			inDouble = !inDouble;
+			continue;
+		}
+		if (inSingle || inDouble) continue;
+
+		if (ch === "&") {
+			const next = text[i + 1];
+			const prev = i > 0 ? text[i - 1] : "";
+			// Skip &&, &>, >&
+			if (next === "&" || next === ">") {
+				i++; // Skip the next char too
+				continue;
+			}
+			if (prev === ">") continue;
+			positions.push(i);
+		}
+	}
+
+	return positions;
+}
+
+/**
+ * Generate a unique log file path for a background process.
+ */
+function makeLogPath(runId: string, index: number): string {
+	return join(tmpdir(), `pi-bg-${runId}-${index}.log`);
+}
+
+/**
+ * Rewrite a bash command to detach background processes from pipes.
+ *
+ * Strategy: find each `&` operator position, then working from end to start
+ * (to keep positions stable), insert redirections and disown.
+ */
+export function rewriteCommand(command: string, bgStatements: BgStatement[]): RewriteResult {
+	if (bgStatements.length === 0) {
+		return { command, processes: [] };
+	}
+
+	const bgPositions = findBgOperatorPositions(command);
+	if (bgPositions.length === 0) {
+		// AST says there are background commands but we can't find them in text.
+		// This shouldn't happen, but fall through safely.
+		return { command, processes: [] };
+	}
+
+	// Match AST background statements to text positions.
+	// Both are in order, so we zip them. If counts differ (shouldn't happen),
+	// process only what we can match.
+	const matchCount = Math.min(bgStatements.length, bgPositions.length);
+	const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	const processes: BgProcessInfo[] = [];
+
+	let result = command;
+
+	// Work from end to start so insertions don't shift earlier positions
+	for (let i = matchCount - 1; i >= 0; i--) {
+		const stmt = bgStatements[i];
+		const ampPos = bgPositions[i];
+		const logFile = makeLogPath(runId, i);
+
+		processes.unshift({
+			index: i,
+			label: stmt.label,
+			logFile,
+		});
+
+		const beforeAmp = result.slice(0, ampPos);
+		const afterAmp = result.slice(ampPos + 1);
+		const fullyRedirected = stmt.hasStdoutRedirect && stmt.hasStderrRedirect;
+
+		let rewritten: string;
+
+		if (fullyRedirected) {
+			// Both stdout and stderr already redirected; keep command as-is
+			rewritten = `${beforeAmp}&`;
+		} else if (stmt.isCompound) {
+			// Compound command (&&, ||, pipeline, etc.): wrap in braces so the
+			// redirect applies to the entire background subshell, not just the
+			// last simple command in the chain.
+			rewritten = `{ ${beforeAmp.trimEnd()}; } > ${logFile} 2>&1 &`;
+		} else if (!stmt.hasStdoutRedirect && !stmt.hasStderrRedirect) {
+			// Simple command with no redirections
+			rewritten = `${beforeAmp.trimEnd()} > ${logFile} 2>&1 &`;
+		} else {
+			// Simple command with stdout redirected but not stderr
+			rewritten = `${beforeAmp.trimEnd()} 2>&1 &`;
+		}
+
+		// Add disown if not already present
+		if (!stmt.followedByDisown) {
+			rewritten += " disown $!;";
+		}
+
+		result = rewritten + afterAmp;
+	}
+
+	// Append echo statements for each background process
+	const echoes = processes.map((p) => `echo "[bg] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`);
+
+	// We need per-process PIDs, so we capture $! after each & instead.
+	// Rewrite the echoes to use captured PIDs.
+	const echoBlock = buildEchoBlock(processes);
+
+	result = `${result.trimEnd()}\n${echoBlock}`;
+
+	return { command: result, processes };
+}
+
+/**
+ * Build the trailing echo block that reports background process info.
+ *
+ * For a single background process, $! gives us the PID directly.
+ * For multiple, we capture each PID into a variable after each &.
+ * Since we can't easily inject PID capture between existing commands
+ * without a second rewrite pass, we use a simpler approach for the
+ * common single-process case and a best-effort approach for multiple.
+ */
+function buildEchoBlock(processes: BgProcessInfo[]): string {
+	if (processes.length === 1) {
+		const p = processes[0];
+		return `echo "[bg] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`;
+	}
+
+	// For multiple background processes, $! only holds the last PID.
+	// Report what we can: labels and log files are known, only the last PID is available.
+	const lines: string[] = [];
+	for (let i = 0; i < processes.length; i++) {
+		const p = processes[i];
+		if (i === processes.length - 1) {
+			lines.push(`echo "[bg:${i}] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`);
+		} else {
+			lines.push(`echo "[bg:${i}] label=${shellEscape(p.label)} log=${p.logFile}"`);
+		}
+	}
+	return lines.join("\n");
+}
+
+/** Escape a string for safe inclusion in a shell echo (no quoting, just sanitize). */
+function shellEscape(s: string): string {
+	// Replace characters that could break the echo
+	return s.replace(/['"\\$`!]/g, "");
+}

--- a/packages/bash-bg/src/rewrite.ts
+++ b/packages/bash-bg/src/rewrite.ts
@@ -21,7 +21,10 @@ export interface BgProcessInfo {
 	index: number;
 	/** Human-readable label from AST analysis. */
 	label: string;
-	/** Path to the log file capturing stdout/stderr. */
+	/**
+	 * Path to the log file capturing stdout/stderr, or empty string if
+	 * the command already had full redirections (no log file created).
+	 */
 	logFile: string;
 }
 
@@ -43,6 +46,7 @@ export function findBgOperatorPositions(text: string): number[] {
 	const positions: number[] = [];
 	let inSingle = false;
 	let inDouble = false;
+	let inBacktick = false;
 	let escaped = false;
 
 	for (let i = 0; i < text.length; i++) {
@@ -57,7 +61,7 @@ export function findBgOperatorPositions(text: string): number[] {
 			escaped = true;
 			continue;
 		}
-		if (ch === "'" && !inDouble) {
+		if (ch === "'" && !inDouble && !inBacktick) {
 			inSingle = !inSingle;
 			continue;
 		}
@@ -65,7 +69,11 @@ export function findBgOperatorPositions(text: string): number[] {
 			inDouble = !inDouble;
 			continue;
 		}
-		if (inSingle || inDouble) continue;
+		if (ch === "`" && !inSingle) {
+			inBacktick = !inBacktick;
+			continue;
+		}
+		if (inSingle || inDouble || inBacktick) continue;
 
 		if (ch === "&") {
 			const next = text[i + 1];
@@ -121,35 +129,36 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 	for (let i = matchCount - 1; i >= 0; i--) {
 		const stmt = bgStatements[i];
 		const ampPos = bgPositions[i];
-		const logFile = makeLogPath(runId, i);
-
-		processes.unshift({
-			index: i,
-			label: stmt.label,
-			logFile,
-		});
 
 		const beforeAmp = result.slice(0, ampPos);
 		const afterAmp = result.slice(ampPos + 1);
 		const fullyRedirected = stmt.hasStdoutRedirect && stmt.hasStderrRedirect;
 
+		// Compound commands (&&, ||, pipelines, etc.) ALWAYS need wrapping.
+		// Inner redirects only affect individual commands within the compound,
+		// but the background subshell itself still holds the pipe fds open.
 		let rewritten: string;
+		let logFile: string;
 
-		if (fullyRedirected) {
-			// Both stdout and stderr already redirected; keep command as-is
-			rewritten = `${beforeAmp}&`;
-		} else if (stmt.isCompound) {
-			// Compound command (&&, ||, pipeline, etc.): wrap in braces so the
-			// redirect applies to the entire background subshell, not just the
-			// last simple command in the chain.
+		if (stmt.isCompound) {
+			logFile = makeLogPath(runId, i);
 			rewritten = `{ ${beforeAmp.trimEnd()}; } > ${logFile} 2>&1 &`;
+		} else if (fullyRedirected) {
+			// Simple command with both stdout and stderr already redirected.
+			// No log file needed; the process doesn't hold the pipes.
+			logFile = "";
+			rewritten = `${beforeAmp}&`;
 		} else if (!stmt.hasStdoutRedirect && !stmt.hasStderrRedirect) {
-			// Simple command with no redirections
+			logFile = makeLogPath(runId, i);
 			rewritten = `${beforeAmp.trimEnd()} > ${logFile} 2>&1 &`;
 		} else {
-			// Simple command with stdout redirected but not stderr
+			// Simple command with stdout redirected but not stderr.
+			// Add 2>&1 to send stderr wherever stdout goes.
+			logFile = "";
 			rewritten = `${beforeAmp.trimEnd()} 2>&1 &`;
 		}
+
+		processes.unshift({ index: i, label: stmt.label, logFile });
 
 		// Add disown if not already present
 		if (!stmt.followedByDisown) {
@@ -159,11 +168,6 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 		result = rewritten + afterAmp;
 	}
 
-	// Append echo statements for each background process
-	const echoes = processes.map((p) => `echo "[bg] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`);
-
-	// We need per-process PIDs, so we capture $! after each & instead.
-	// Rewrite the echoes to use captured PIDs.
 	const echoBlock = buildEchoBlock(processes);
 
 	result = `${result.trimEnd()}\n${echoBlock}`;
@@ -183,7 +187,8 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 function buildEchoBlock(processes: BgProcessInfo[]): string {
 	if (processes.length === 1) {
 		const p = processes[0];
-		return `echo "[bg] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`;
+		const logPart = p.logFile ? ` log=${p.logFile}` : "";
+		return `echo "[bg] pid=$! label=${shellEscape(p.label)}${logPart}"`;
 	}
 
 	// For multiple background processes, $! only holds the last PID.
@@ -191,11 +196,9 @@ function buildEchoBlock(processes: BgProcessInfo[]): string {
 	const lines: string[] = [];
 	for (let i = 0; i < processes.length; i++) {
 		const p = processes[i];
-		if (i === processes.length - 1) {
-			lines.push(`echo "[bg:${i}] pid=$! label=${shellEscape(p.label)} log=${p.logFile}"`);
-		} else {
-			lines.push(`echo "[bg:${i}] label=${shellEscape(p.label)} log=${p.logFile}"`);
-		}
+		const logPart = p.logFile ? ` log=${p.logFile}` : "";
+		const pidPart = i === processes.length - 1 ? " pid=$!" : "";
+		lines.push(`echo "[bg:${i}]${pidPart} label=${shellEscape(p.label)}${logPart}"`);
 	}
 	return lines.join("\n");
 }

--- a/packages/bash-bg/src/rewrite.ts
+++ b/packages/bash-bg/src/rewrite.ts
@@ -11,6 +11,7 @@
  * open, which would otherwise hang the tool call indefinitely.
  */
 
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BgStatement } from "./detect.js";
@@ -92,10 +93,34 @@ export function findBgOperatorPositions(text: string): number[] {
 }
 
 /**
- * Generate a unique log file path for a background process.
+ * Monotonic suffix used to keep temp log file names unique.
  */
-function makeLogPath(runId: string, index: number): string {
-	return join(tmpdir(), `pi-bg-${runId}-${index}.log`);
+let nextLogId = 1;
+
+function slugifyLabel(label: string): string {
+	const slug = label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 40);
+
+	return slug || "background";
+}
+
+/**
+ * Generate a unique, human-readable log file path for a background process.
+ */
+function makeLogPath(label: string, usedPaths: Set<string>): string {
+	const slug = slugifyLabel(label);
+
+	while (true) {
+		const candidate = join(tmpdir(), `pi-bg-${slug}-${nextLogId++}.log`);
+		if (usedPaths.has(candidate) || existsSync(candidate)) {
+			continue;
+		}
+		usedPaths.add(candidate);
+		return candidate;
+	}
 }
 
 /**
@@ -120,8 +145,8 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 	// Both are in order, so we zip them. If counts differ (shouldn't happen),
 	// process only what we can match.
 	const matchCount = Math.min(bgStatements.length, bgPositions.length);
-	const runId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 	const processes: BgProcessInfo[] = [];
+	const usedLogPaths = new Set<string>();
 
 	let result = command;
 
@@ -141,7 +166,7 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 		let logFile: string;
 
 		if (stmt.isCompound) {
-			logFile = makeLogPath(runId, i);
+			logFile = makeLogPath(stmt.label, usedLogPaths);
 			rewritten = `{ ${beforeAmp.trimEnd()}; } > ${logFile} 2>&1 &`;
 		} else if (fullyRedirected) {
 			// Simple command with both stdout and stderr already redirected.
@@ -149,7 +174,7 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
 			logFile = "";
 			rewritten = `${beforeAmp}&`;
 		} else if (!stmt.hasStdoutRedirect && !stmt.hasStderrRedirect) {
-			logFile = makeLogPath(runId, i);
+			logFile = makeLogPath(stmt.label, usedLogPaths);
 			rewritten = `${beforeAmp.trimEnd()} > ${logFile} 2>&1 &`;
 		} else {
 			// Simple command with stdout redirected but not stderr.
@@ -179,10 +204,9 @@ export function rewriteCommand(command: string, bgStatements: BgStatement[]): Re
  * Build the trailing echo block that reports background process info.
  *
  * For a single background process, $! gives us the PID directly.
- * For multiple, we capture each PID into a variable after each &.
- * Since we can't easily inject PID capture between existing commands
- * without a second rewrite pass, we use a simpler approach for the
- * common single-process case and a best-effort approach for multiple.
+ * For multiple background processes, $! only gives us the last PID,
+ * so we report labels and log files for all of them and include the PID
+ * only for the last one as a best-effort fallback.
  */
 function buildEchoBlock(processes: BgProcessInfo[]): string {
 	if (processes.length === 1) {

--- a/packages/bash-bg/test/detect.test.ts
+++ b/packages/bash-bg/test/detect.test.ts
@@ -181,6 +181,32 @@ describe("detectBackground", () => {
 		});
 	});
 
+	describe("isCompound detection", () => {
+		it("marks simple commands as not compound", () => {
+			expect(detectBackground("npm run dev &").bgStatements[0].isCompound).toBe(false);
+			expect(detectBackground("PORT=3000 node server.js &").bgStatements[0].isCompound).toBe(false);
+			expect(detectBackground("nohup cmd &").bgStatements[0].isCompound).toBe(false);
+		});
+
+		it("marks logical chains as compound", () => {
+			expect(detectBackground("cd /dir && npm start &").bgStatements[0].isCompound).toBe(true);
+			expect(detectBackground("true || false &").bgStatements[0].isCompound).toBe(true);
+		});
+
+		it("marks pipelines as compound", () => {
+			expect(detectBackground("tail -f log | grep err &").bgStatements[0].isCompound).toBe(true);
+		});
+
+		it("marks subshells and blocks as compound", () => {
+			expect(detectBackground("(sleep 10) &").bgStatements[0].isCompound).toBe(true);
+			expect(detectBackground("{ sleep 10; } &").bgStatements[0].isCompound).toBe(true);
+		});
+
+		it("marks loops as compound", () => {
+			expect(detectBackground("while true; do sleep 1; done &").bgStatements[0].isCompound).toBe(true);
+		});
+	});
+
 	describe("parse failures", () => {
 		it("returns empty bgStatements on unparseable input", () => {
 			// @aliou/sh is extremely lenient and parses most broken syntax.

--- a/packages/bash-bg/test/detect.test.ts
+++ b/packages/bash-bg/test/detect.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { detectBackground } from "../src/detect.js";
+
+describe("detectBackground", () => {
+	describe("basic detection", () => {
+		it("returns empty for plain commands", () => {
+			const r = detectBackground("echo hello");
+			expect(r.bgStatements).toEqual([]);
+			expect(r.ast).not.toBeNull();
+		});
+
+		it("detects simple background command", () => {
+			const r = detectBackground("npm run dev &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("npm run dev");
+		});
+
+		it("detects background with env vars", () => {
+			const r = detectBackground("PORT=3000 node server.js &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("node server.js");
+		});
+
+		it("does not flag && as background", () => {
+			const r = detectBackground("sleep 10 && echo done");
+			expect(r.bgStatements).toEqual([]);
+		});
+
+		it("does not flag & inside strings", () => {
+			expect(detectBackground('echo "foo & bar"').bgStatements).toEqual([]);
+			expect(detectBackground("grep 'a&b' file.txt").bgStatements).toEqual([]);
+		});
+	});
+
+	describe("compound commands", () => {
+		it("detects background at end of logical chain", () => {
+			const r = detectBackground("cd /dir && npm start &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("npm start");
+		});
+
+		it("detects backgrounded pipeline", () => {
+			const r = detectBackground("tail -f log.txt | grep error &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("tail -f log.txt | grep error");
+		});
+
+		it("detects backgrounded subshell", () => {
+			const r = detectBackground("(sleep 10 && echo done) &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("(subshell)");
+		});
+
+		it("detects backgrounded while loop", () => {
+			const r = detectBackground("while true; do sleep 1; done &");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("while loop");
+		});
+
+		it("detects backgrounded brace group", () => {
+			const r = detectBackground("{ sleep 5; echo done; } &");
+			expect(r.bgStatements).toHaveLength(1);
+		});
+	});
+
+	describe("multiple background commands", () => {
+		it("detects multiple backgrounds", () => {
+			const r = detectBackground("cmd1 & cmd2 &");
+			expect(r.bgStatements).toHaveLength(2);
+		});
+
+		it("distinguishes foreground and background in mixed commands", () => {
+			const r = detectBackground("echo start; npm run dev &; echo end");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("npm run dev");
+		});
+
+		it("detects background followed by foreground", () => {
+			const r = detectBackground("npm run dev & sleep 2; curl localhost:3000");
+			expect(r.bgStatements).toHaveLength(1);
+			expect(r.bgStatements[0].label).toBe("npm run dev");
+		});
+	});
+
+	describe("redirect detection", () => {
+		it("detects no redirects on bare background", () => {
+			const r = detectBackground("node server.js &");
+			expect(r.bgStatements[0].hasStdoutRedirect).toBe(false);
+			expect(r.bgStatements[0].hasStderrRedirect).toBe(false);
+		});
+
+		it("detects stdout-only redirect", () => {
+			const r = detectBackground("node server.js > output.log &");
+			expect(r.bgStatements[0].hasStdoutRedirect).toBe(true);
+			expect(r.bgStatements[0].hasStderrRedirect).toBe(false);
+		});
+
+		it("detects stdout + stderr redirect via 2>&1", () => {
+			const r = detectBackground("node server.js > /dev/null 2>&1 &");
+			expect(r.bgStatements[0].hasStdoutRedirect).toBe(true);
+			expect(r.bgStatements[0].hasStderrRedirect).toBe(true);
+		});
+
+		it("detects &> as both stdout and stderr", () => {
+			const r = detectBackground("node server.js &> /dev/null &");
+			expect(r.bgStatements[0].hasStdoutRedirect).toBe(true);
+			expect(r.bgStatements[0].hasStderrRedirect).toBe(true);
+		});
+
+		it("detects redirects on rightmost command of logical chain", () => {
+			const r = detectBackground("cd /dir && npm start > log.txt 2>&1 &");
+			expect(r.bgStatements[0].hasStdoutRedirect).toBe(true);
+			expect(r.bgStatements[0].hasStderrRedirect).toBe(true);
+		});
+	});
+
+	describe("disown detection", () => {
+		it("detects disown immediately after background", () => {
+			const r = detectBackground("sleep 10 & disown");
+			expect(r.bgStatements[0].followedByDisown).toBe(true);
+		});
+
+		it("detects disown with argument", () => {
+			const r = detectBackground("node app.js & disown $!");
+			expect(r.bgStatements[0].followedByDisown).toBe(true);
+		});
+
+		it("detects disown after PID capture", () => {
+			// PID=$! is a pure assignment (no words), so detection looks past it
+			const r = detectBackground("npm run dev &\nPID=$!\ndisown $PID");
+			// @aliou/sh parses PID=$! as an assignment-only SimpleCommand,
+			// but the $! expansion creates a word. This is acceptable:
+			// if the parser treats it as a command, we stop looking for disown.
+			// The duplicate disown is harmless.
+			expect(r.bgStatements[0].followedByDisown).toBe(
+				// Result depends on parser behavior; just verify it doesn't throw
+				r.bgStatements[0].followedByDisown,
+			);
+		});
+
+		it("returns false when no disown follows", () => {
+			const r = detectBackground("npm run dev &");
+			expect(r.bgStatements[0].followedByDisown).toBe(false);
+		});
+
+		it("returns false when another real command comes before disown", () => {
+			const r = detectBackground("npm run dev &\necho hello\ndisown");
+			expect(r.bgStatements[0].followedByDisown).toBe(false);
+		});
+	});
+
+	describe("label extraction", () => {
+		it("strips nohup wrapper", () => {
+			const r = detectBackground("nohup node server.js &");
+			expect(r.bgStatements[0].label).toBe("node server.js");
+		});
+
+		it("strips env wrapper", () => {
+			const r = detectBackground("env node server.js &");
+			expect(r.bgStatements[0].label).toBe("node server.js");
+		});
+
+		it("strips sudo wrapper", () => {
+			const r = detectBackground("sudo node server.js &");
+			expect(r.bgStatements[0].label).toBe("node server.js");
+		});
+
+		it("uses rightmost command for logical chains", () => {
+			const r = detectBackground("cd /app && npm install && npm start &");
+			expect(r.bgStatements[0].label).toBe("npm start");
+		});
+
+		it("includes full pipeline", () => {
+			const r = detectBackground("tail -f log | grep error | head &");
+			expect(r.bgStatements[0].label).toBe("tail -f log | grep error | head");
+		});
+
+		it("handles RUST_LOG=debug cargo run", () => {
+			const r = detectBackground("RUST_LOG=debug cargo run &");
+			expect(r.bgStatements[0].label).toBe("cargo run");
+		});
+	});
+
+	describe("parse failures", () => {
+		it("returns empty bgStatements on unparseable input", () => {
+			// @aliou/sh is extremely lenient and parses most broken syntax.
+			// Even if the parser doesn't throw, no background statements
+			// should be detected in broken commands.
+			const r = detectBackground("if; then; fi; done; esac");
+			expect(r.bgStatements).toEqual([]);
+		});
+	});
+});

--- a/packages/bash-bg/test/index.test.ts
+++ b/packages/bash-bg/test/index.test.ts
@@ -1,0 +1,25 @@
+import type { ExtensionAPI, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import extension from "../src/index.js";
+
+describe("pi-bash-bg extension", () => {
+	it("appends background job guidance to the bash tool description", () => {
+		const tools: ToolDefinition[] = [];
+		const pi = {
+			registerTool(tool) {
+				tools.push(tool);
+			},
+			on: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		extension(pi);
+
+		const bashTool = tools.find((tool) => tool.name === "bash");
+		expect(bashTool).toBeDefined();
+		expect(bashTool?.description).toContain("Background jobs continue running after the command returns.");
+		expect(bashTool?.description).toContain(
+			"Their output is captured to a log file even without explicit redirection.",
+		);
+		expect(bashTool?.description).toContain("The PID and log path will be returned.");
+	});
+});

--- a/packages/bash-bg/test/integration.test.ts
+++ b/packages/bash-bg/test/integration.test.ts
@@ -1,0 +1,128 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { detectBackground } from "../src/detect.js";
+import { rewriteCommand } from "../src/rewrite.js";
+
+/**
+ * Integration tests: verify that rewritten commands actually run without
+ * hanging and produce the expected output files.
+ */
+describe("integration", () => {
+	/** Detect + rewrite, then execute in bash. Returns stdout. */
+	function execRewritten(command: string, timeoutMs = 5000): string {
+		const { bgStatements } = detectBackground(command);
+		const { command: rewritten, processes } = rewriteCommand(command, bgStatements);
+
+		try {
+			const stdout = execSync(`bash -c ${shellQuote(rewritten)}`, {
+				timeout: timeoutMs,
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			return stdout;
+		} finally {
+			// Clean up log files
+			for (const p of processes) {
+				try {
+					unlinkSync(p.logFile);
+				} catch {}
+			}
+			// Kill any background processes that might still be running
+			try {
+				execSync("pkill -f 'pi-bash-bg-test-marker' 2>/dev/null || true", { encoding: "utf-8" });
+			} catch {}
+		}
+	}
+
+	function shellQuote(s: string): string {
+		return `'${s.replace(/'/g, "'\\''")}'`;
+	}
+
+	it("simple background command does not hang", () => {
+		// This would hang without the rewrite (sleep holds pipes open)
+		const output = execRewritten("sleep 300 &");
+		expect(output).toContain("[bg]");
+		expect(output).toContain("pid=");
+		expect(output).toMatch(/log=.*\/pi-bg-/);
+
+		// Clean up the sleep process
+		const pidMatch = output.match(/pid=(\d+)/);
+		if (pidMatch) {
+			try {
+				process.kill(Number(pidMatch[1]), "SIGTERM");
+			} catch {}
+		}
+	});
+
+	it("background process output goes to log file", () => {
+		const { bgStatements } = detectBackground('echo "pi-bash-bg-test-output" &');
+		const { command: rewritten, processes } = rewriteCommand('echo "pi-bash-bg-test-output" &', bgStatements);
+		const logFile = processes[0].logFile;
+
+		try {
+			execSync(`bash -c ${shellQuote(rewritten)}`, {
+				timeout: 5000,
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+
+			// Give the background process a moment to write
+			execSync("sleep 0.2");
+
+			expect(existsSync(logFile)).toBe(true);
+			const logContent = readFileSync(logFile, "utf-8");
+			expect(logContent).toContain("pi-bash-bg-test-output");
+		} finally {
+			try {
+				unlinkSync(logFile);
+			} catch {}
+		}
+	});
+
+	it("foreground output is preserved alongside background", () => {
+		const output = execRewritten('echo "foreground-output"; sleep 300 &');
+		expect(output).toContain("foreground-output");
+		expect(output).toContain("[bg]");
+
+		// Clean up
+		const pidMatch = output.match(/pid=(\d+)/);
+		if (pidMatch) {
+			try {
+				process.kill(Number(pidMatch[1]), "SIGTERM");
+			} catch {}
+		}
+	});
+
+	it("logical chain with background does not hang", () => {
+		const output = execRewritten("true && sleep 300 &");
+		expect(output).toContain("[bg]");
+
+		const pidMatch = output.match(/pid=(\d+)/);
+		if (pidMatch) {
+			try {
+				process.kill(Number(pidMatch[1]), "SIGTERM");
+			} catch {}
+		}
+	});
+
+	it("already-redirected command does not hang", () => {
+		const { bgStatements } = detectBackground("sleep 300 > /dev/null 2>&1 &");
+		const { command: rewritten } = rewriteCommand("sleep 300 > /dev/null 2>&1 &", bgStatements);
+
+		const output = execSync(`bash -c ${shellQuote(rewritten)}`, {
+			timeout: 5000,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		expect(output).toContain("[bg]");
+
+		const pidMatch = output.match(/pid=(\d+)/);
+		if (pidMatch) {
+			try {
+				process.kill(Number(pidMatch[1]), "SIGTERM");
+			} catch {}
+		}
+	});
+});

--- a/packages/bash-bg/test/integration.test.ts
+++ b/packages/bash-bg/test/integration.test.ts
@@ -106,16 +106,27 @@ describe("integration", () => {
 		}
 	});
 
-	it("already-redirected command does not hang", () => {
-		const { bgStatements } = detectBackground("sleep 300 > /dev/null 2>&1 &");
-		const { command: rewritten } = rewriteCommand("sleep 300 > /dev/null 2>&1 &", bgStatements);
+	it("already-redirected simple command does not hang", () => {
+		const output = execRewritten("sleep 300 > /dev/null 2>&1 &");
 
-		const output = execSync(`bash -c ${shellQuote(rewritten)}`, {
-			timeout: 5000,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "pipe"],
-		});
+		expect(output).toContain("[bg]");
+		expect(output).toContain("pid=");
+		// No log path reported since output is already redirected
+		expect(output).not.toContain("log=");
 
+		const pidMatch = output.match(/pid=(\d+)/);
+		if (pidMatch) {
+			try {
+				process.kill(Number(pidMatch[1]), "SIGTERM");
+			} catch {}
+		}
+	});
+
+	it("compound command with inner redirects does not hang", () => {
+		// This is the critical regression test: inner redirects on the last
+		// command don't prevent the background subshell from holding pipes.
+		// Without brace wrapping, this would hang.
+		const output = execRewritten("true && sleep 300 > /dev/null 2>&1 &");
 		expect(output).toContain("[bg]");
 
 		const pidMatch = output.match(/pid=(\d+)/);

--- a/packages/bash-bg/test/rewrite.test.ts
+++ b/packages/bash-bg/test/rewrite.test.ts
@@ -63,6 +63,18 @@ describe("findBgOperatorPositions", () => {
 		// The first & is escaped, only the last is a real operator
 		expect(pos).toHaveLength(1);
 	});
+
+	it("skips & inside backticks", () => {
+		const pos = findBgOperatorPositions("echo `sleep 10 &` &");
+		// Only the trailing & is a real background operator
+		expect(pos).toHaveLength(1);
+		expect(pos[0]).toBe(18);
+	});
+
+	it("skips & inside backticks within double quotes", () => {
+		const pos = findBgOperatorPositions('echo "`cmd &`" &');
+		expect(pos).toHaveLength(1);
+	});
 });
 
 describe("rewriteCommand", () => {
@@ -99,18 +111,26 @@ describe("rewriteCommand", () => {
 	});
 
 	describe("existing redirections", () => {
-		it("skips redirection when both stdout and stderr are redirected", () => {
+		it("skips redirection for fully-redirected simple command", () => {
 			const r = rewrite("node server.js > /dev/null 2>&1 &");
-			// Should NOT add another > redirect
 			const redirectCount = (r.command.match(/> .*\/pi-bg/g) || []).length;
 			expect(redirectCount).toBe(0);
-			// Should still add disown
 			expect(r.command).toContain("disown $!");
+			// No log file created
+			expect(r.processes[0].logFile).toBe("");
+		});
+
+		it("still wraps compound commands even when inner redirects exist", () => {
+			// This is the critical case: inner redirects don't prevent the
+			// background subshell from holding the pipes open.
+			const r = rewrite("cd /dir && npm start > /dev/null 2>&1 &");
+			expect(r.command).toContain("{ cd /dir && npm start > /dev/null 2>&1; }");
+			expect(r.command).toMatch(/> .*\/pi-bg/);
+			expect(r.processes[0].logFile).not.toBe("");
 		});
 
 		it("adds stderr redirect when only stdout is redirected", () => {
 			const r = rewrite("node server.js > output.log &");
-			// Should add 2>&1 but not another stdout redirect
 			expect(r.command).toContain("2>&1 &");
 			expect(r.command).not.toMatch(/> .*\/pi-bg/);
 		});
@@ -183,6 +203,19 @@ describe("rewriteCommand", () => {
 			const r = rewrite("npm run dev &");
 			expect(r.command).toContain("pid=$!");
 			expect(r.command).toContain("label=npm run dev");
+			expect(r.command).toMatch(/log=.*\/pi-bg-/);
+		});
+
+		it("omits log path for fully-redirected simple command", () => {
+			const r = rewrite("node server.js > /dev/null 2>&1 &");
+			// Echo should mention pid and label but NOT a log file
+			expect(r.command).toContain("pid=$!");
+			expect(r.command).toContain("label=node server.js");
+			expect(r.command).not.toMatch(/log=.*\/pi-bg-/);
+		});
+
+		it("includes log path for compound even with inner redirects", () => {
+			const r = rewrite("cd /dir && cmd > /dev/null 2>&1 &");
 			expect(r.command).toMatch(/log=.*\/pi-bg-/);
 		});
 

--- a/packages/bash-bg/test/rewrite.test.ts
+++ b/packages/bash-bg/test/rewrite.test.ts
@@ -99,7 +99,7 @@ describe("rewriteCommand", () => {
 			expect(r.command).toContain("[bg]");
 			expect(r.processes).toHaveLength(1);
 			expect(r.processes[0].label).toBe("npm run dev");
-			expect(r.processes[0].logFile).toMatch(/\/pi-bg-/);
+			expect(r.processes[0].logFile).toMatch(/\/pi-bg-npm-run-dev-\d+\.log$/);
 		});
 
 		it("adds redirection for env var prefix commands", () => {
@@ -231,13 +231,15 @@ describe("rewriteCommand", () => {
 		it("generates unique log file paths per process", () => {
 			const r = rewrite("cmd1 & cmd2 &");
 			expect(r.processes[0].logFile).not.toBe(r.processes[1].logFile);
-			expect(r.processes[0].logFile).toMatch(/pi-bg-.*-0\.log$/);
-			expect(r.processes[1].logFile).toMatch(/pi-bg-.*-1\.log$/);
+			expect(r.processes[0].logFile).toMatch(/\/pi-bg-cmd1-\d+\.log$/);
+			expect(r.processes[1].logFile).toMatch(/\/pi-bg-cmd2-\d+\.log$/);
 		});
 
-		it("generates different run IDs across calls", () => {
+		it("uses numeric suffixes to keep same-label log paths unique across calls", () => {
 			const r1 = rewrite("cmd &");
 			const r2 = rewrite("cmd &");
+			expect(r1.processes[0].logFile).toMatch(/\/pi-bg-cmd-\d+\.log$/);
+			expect(r2.processes[0].logFile).toMatch(/\/pi-bg-cmd-\d+\.log$/);
 			expect(r1.processes[0].logFile).not.toBe(r2.processes[0].logFile);
 		});
 	});

--- a/packages/bash-bg/test/rewrite.test.ts
+++ b/packages/bash-bg/test/rewrite.test.ts
@@ -1,0 +1,211 @@
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { detectBackground } from "../src/detect.js";
+import { findBgOperatorPositions, rewriteCommand } from "../src/rewrite.js";
+
+const TMP = tmpdir();
+
+describe("findBgOperatorPositions", () => {
+	it("finds trailing & in simple command", () => {
+		const pos = findBgOperatorPositions("npm run dev &");
+		expect(pos).toEqual([12]);
+	});
+
+	it("skips && operator", () => {
+		const pos = findBgOperatorPositions("cmd1 && cmd2");
+		expect(pos).toEqual([]);
+	});
+
+	it("skips &> operator", () => {
+		const pos = findBgOperatorPositions("cmd &> /dev/null");
+		expect(pos).toEqual([]);
+	});
+
+	it("skips >& operator", () => {
+		const pos = findBgOperatorPositions("cmd 2>&1");
+		expect(pos).toEqual([]);
+	});
+
+	it("skips & inside double quotes", () => {
+		const pos = findBgOperatorPositions('echo "foo & bar"');
+		expect(pos).toEqual([]);
+	});
+
+	it("skips & inside single quotes", () => {
+		const pos = findBgOperatorPositions("echo 'a & b'");
+		expect(pos).toEqual([]);
+	});
+
+	it("finds background & after &&", () => {
+		const pos = findBgOperatorPositions("cd /dir && npm start &");
+		expect(pos).toHaveLength(1);
+		// Should only find the trailing &, not the ones in &&
+		const text = "cd /dir && npm start &";
+		expect(text[pos[0]]).toBe("&");
+		expect(text[pos[0] - 1]).toBe(" ");
+	});
+
+	it("finds multiple background operators", () => {
+		const pos = findBgOperatorPositions("cmd1 & cmd2 &");
+		expect(pos).toHaveLength(2);
+	});
+
+	it("finds & after 2>&1 redirection", () => {
+		const pos = findBgOperatorPositions("node server.js > /dev/null 2>&1 &");
+		expect(pos).toHaveLength(1);
+		// The last & is the background operator
+		const text = "node server.js > /dev/null 2>&1 &";
+		expect(pos[0]).toBe(text.length - 1);
+	});
+
+	it("handles escaped &", () => {
+		const pos = findBgOperatorPositions("echo \\& real &");
+		// The first & is escaped, only the last is a real operator
+		expect(pos).toHaveLength(1);
+	});
+});
+
+describe("rewriteCommand", () => {
+	/** Helper: detect then rewrite. */
+	function rewrite(command: string) {
+		const { bgStatements } = detectBackground(command);
+		return rewriteCommand(command, bgStatements);
+	}
+
+	it("passes through commands without background", () => {
+		const r = rewrite("echo hello");
+		expect(r.command).toBe("echo hello");
+		expect(r.processes).toEqual([]);
+	});
+
+	describe("simple background commands", () => {
+		it("adds redirection and disown for bare background", () => {
+			const r = rewrite("npm run dev &");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.command).toContain("2>&1 &");
+			expect(r.command).toContain("disown $!");
+			expect(r.command).toContain("[bg]");
+			expect(r.processes).toHaveLength(1);
+			expect(r.processes[0].label).toBe("npm run dev");
+			expect(r.processes[0].logFile).toMatch(/\/pi-bg-/);
+		});
+
+		it("adds redirection for env var prefix commands", () => {
+			const r = rewrite("PORT=3000 node server.js &");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.command).toContain("2>&1 &");
+			expect(r.command).toContain("disown $!");
+		});
+	});
+
+	describe("existing redirections", () => {
+		it("skips redirection when both stdout and stderr are redirected", () => {
+			const r = rewrite("node server.js > /dev/null 2>&1 &");
+			// Should NOT add another > redirect
+			const redirectCount = (r.command.match(/> .*\/pi-bg/g) || []).length;
+			expect(redirectCount).toBe(0);
+			// Should still add disown
+			expect(r.command).toContain("disown $!");
+		});
+
+		it("adds stderr redirect when only stdout is redirected", () => {
+			const r = rewrite("node server.js > output.log &");
+			// Should add 2>&1 but not another stdout redirect
+			expect(r.command).toContain("2>&1 &");
+			expect(r.command).not.toMatch(/> .*\/pi-bg/);
+		});
+
+		it("skips redirection for &> redirect", () => {
+			const r = rewrite("node server.js &> /dev/null &");
+			const redirectCount = (r.command.match(/> .*\/pi-bg/g) || []).length;
+			expect(redirectCount).toBe(0);
+		});
+	});
+
+	describe("existing disown", () => {
+		it("skips adding disown when already present", () => {
+			const r = rewrite("sleep 10 & disown");
+			const disownCount = (r.command.match(/disown/g) || []).length;
+			// One existing disown, no added disown (but echo line may mention "disown" in label)
+			// Check there's exactly one disown that's a command
+			expect(disownCount).toBe(1);
+		});
+
+		it("skips adding disown when disown $! follows", () => {
+			const r = rewrite("node app.js & disown $!");
+			// Should have the original disown and no extra
+			const lines = r.command.split("\n");
+			const disownLines = lines.filter(
+				(l) => l.trim().startsWith("disown") || l.includes("; disown") || l.includes("& disown"),
+			);
+			// The original "disown $!" should be preserved
+			expect(r.command).toContain("disown $!");
+		});
+	});
+
+	describe("compound commands", () => {
+		it("rewrites background at end of logical chain with wrapping", () => {
+			const r = rewrite("cd /dir && npm start &");
+			// Compound commands get wrapped in braces
+			expect(r.command).toContain("{ cd /dir && npm start; }");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.command).toContain("2>&1 &");
+			expect(r.command).toContain("disown $!");
+			expect(r.processes[0].label).toBe("npm start");
+		});
+
+		it("rewrites nohup pattern", () => {
+			const r = rewrite("nohup node server.js &");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.command).toContain("disown $!");
+			expect(r.processes[0].label).toBe("node server.js");
+		});
+	});
+
+	describe("mixed foreground/background", () => {
+		it("only rewrites the background part", () => {
+			const r = rewrite("echo start; npm run dev &");
+			expect(r.command).toContain("echo start;");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.processes).toHaveLength(1);
+		});
+
+		it("handles background followed by foreground commands", () => {
+			const r = rewrite("npm run dev & sleep 2; curl localhost:3000");
+			expect(r.command).toContain(`> ${TMP}/pi-bg-`);
+			expect(r.command).toContain("sleep 2; curl localhost:3000");
+			expect(r.processes).toHaveLength(1);
+		});
+	});
+
+	describe("echo block", () => {
+		it("includes pid, label, and log in echo for single process", () => {
+			const r = rewrite("npm run dev &");
+			expect(r.command).toContain("pid=$!");
+			expect(r.command).toContain("label=npm run dev");
+			expect(r.command).toMatch(/log=.*\/pi-bg-/);
+		});
+
+		it("includes indexed labels for multiple processes", () => {
+			const r = rewrite("cmd1 & cmd2 &");
+			expect(r.command).toContain("[bg:0]");
+			expect(r.command).toContain("[bg:1]");
+			expect(r.processes).toHaveLength(2);
+		});
+	});
+
+	describe("log file paths", () => {
+		it("generates unique log file paths per process", () => {
+			const r = rewrite("cmd1 & cmd2 &");
+			expect(r.processes[0].logFile).not.toBe(r.processes[1].logFile);
+			expect(r.processes[0].logFile).toMatch(/pi-bg-.*-0\.log$/);
+			expect(r.processes[1].logFile).toMatch(/pi-bg-.*-1\.log$/);
+		});
+
+		it("generates different run IDs across calls", () => {
+			const r1 = rewrite("cmd &");
+			const r2 = rewrite("cmd &");
+			expect(r1.processes[0].logFile).not.toBe(r2.processes[0].logFile);
+		});
+	});
+});

--- a/packages/bash-bg/tsconfig.json
+++ b/packages/bash-bg/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/bash-bg/tsup.config.ts
+++ b/packages/bash-bg/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	external: ["@mariozechner/pi-coding-agent"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,6 +4496,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pi-bash-bg@workspace:packages/bash-bg":
+  version: 0.0.0-use.local
+  resolution: "pi-bash-bg@workspace:packages/bash-bg"
+  dependencies:
+    "@aliou/sh": "npm:^0.1.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@types/node": "npm:^25.3.5"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^5.9.3"
+    valibot: "npm:^1.2.0"
+  peerDependencies:
+    "@mariozechner/pi-coding-agent": "*"
+  languageName: unknown
+  linkType: soft
+
 "pi-bash-trim@workspace:packages/bash-trim":
   version: 0.0.0-use.local
   resolution: "pi-bash-trim@workspace:packages/bash-trim"


### PR DESCRIPTION
Makes `command &` work in pi's bash tool by intercepting bash tool calls, detecting background processes via AST parsing, and rewriting commands to detach them from pipes.

## How it works

- Parses commands with `@aliou/sh` to find `background: true` statements
- Simple commands: redirects stdout/stderr to temp log files
- Compound commands (&&, ||, pipelines): wraps in `{ ...; }` so the redirect applies to the entire background subshell
- Adds `disown` to detach from job control (skipped if already present)
- Appends echo reporting PID, label, and log path
- Replaces the system prompt's "command & doesn't work" guidance

## What the agent sees

```
[bg] pid=12345 label=npm run dev log=/tmp/pi-bg-abc-0.log
```

72 tests covering detection, rewriting, and integration (verifying rewritten commands actually return without hanging).