### PR TITLE
enclave: redirect /tmp writes from host extensions into VM

### DIFF
--- a/.changeset/tmp-redirect.md
+++ b/.changeset/tmp-redirect.md
@@ -1,0 +1,5 @@
+---
+"pi-enclave": minor
+---
+
+Redirect /tmp file operations from host-side extensions into the VM. Files written to /tmp by other pi extensions (e.g. librarian saving fetched content) are now visible inside the enclave at their original paths. Uses ESM loader hooks and CJS monkey-patching for comprehensive interception without exposing the full host /tmp. Users who need complete /tmp visibility can add `mounts = ["/tmp"]` to their enclave config.

--- a/packages/enclave/src/fs-loader-hooks.mjs
+++ b/packages/enclave/src/fs-loader-hooks.mjs
@@ -1,0 +1,185 @@
+/**
+ * ESM loader hooks that replace node:fs and node:fs/promises imports with
+ * wrapper modules. Path-taking functions delegate through the CJS exports
+ * object so monkey-patches are visible. All other exports (constants,
+ * classes, fd-based functions) are re-exported directly.
+ *
+ * Registered via module.register() in tmp-redirect.ts.
+ * Runs in a separate loader worker thread.
+ */
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+// ---------------------------------------------------------------------------
+// Functions that need delegation (path-taking, may be monkey-patched).
+// Delegation means: export function X(...a) { return _m.X(...a); }
+// This ensures each call reads the CURRENT value of _m.X, picking up patches.
+// ---------------------------------------------------------------------------
+
+const FS_DELEGATED = new Set([
+	// single-path sync
+	"accessSync",
+	"appendFileSync",
+	"chmodSync",
+	"chownSync",
+	"existsSync",
+	"lstatSync",
+	"mkdirSync",
+	"mkdtempSync",
+	"opendirSync",
+	"openSync",
+	"readdirSync",
+	"readFileSync",
+	"readlinkSync",
+	"realpathSync",
+	"rmdirSync",
+	"rmSync",
+	"statSync",
+	"statfsSync",
+	"truncateSync",
+	"unlinkSync",
+	"utimesSync",
+	"writeFileSync",
+	// single-path async (callback)
+	"access",
+	"appendFile",
+	"chmod",
+	"chown",
+	"exists",
+	"lstat",
+	"mkdir",
+	"mkdtemp",
+	"open",
+	"opendir",
+	"readdir",
+	"readFile",
+	"readlink",
+	"realpath",
+	"rm",
+	"rmdir",
+	"stat",
+	"statfs",
+	"truncate",
+	"unlink",
+	"utimes",
+	"writeFile",
+	// streams
+	"createReadStream",
+	"createWriteStream",
+	// two-path sync
+	"copyFileSync",
+	"cpSync",
+	"linkSync",
+	"renameSync",
+	"symlinkSync",
+	// two-path async (callback)
+	"copyFile",
+	"cp",
+	"link",
+	"rename",
+	"symlink",
+	// glob (takes path patterns)
+	"glob",
+	"globSync",
+	// watch (takes path)
+	"watch",
+	"watchFile",
+	"unwatchFile",
+	// lchmod/lchown (take path)
+	"lchmodSync",
+	"lchmod",
+	"lchownSync",
+	"lchown",
+	"lutimesSync",
+	"lutimes",
+]);
+
+const FSP_DELEGATED = new Set([
+	"access",
+	"appendFile",
+	"chmod",
+	"chown",
+	"copyFile",
+	"cp",
+	"glob",
+	"lchmod",
+	"lchown",
+	"link",
+	"lstat",
+	"lutimes",
+	"mkdir",
+	"mkdtemp",
+	"open",
+	"opendir",
+	"readFile",
+	"readdir",
+	"readlink",
+	"realpath",
+	"rename",
+	"rm",
+	"rmdir",
+	"stat",
+	"statfs",
+	"symlink",
+	"truncate",
+	"unlink",
+	"utimes",
+	"writeFile",
+	"watch",
+]);
+
+// ---------------------------------------------------------------------------
+// Source generation
+// ---------------------------------------------------------------------------
+
+function generateWrapperSource(cjsModuleName, delegatedSet) {
+	const mod = require(cjsModuleName);
+	const lines = [
+		"import { createRequire as _cr } from 'node:module';",
+		"const _r = _cr('file:///tmp/_pi_enclave_loader.js');",
+		`const _m = _r("${cjsModuleName}");`,
+	];
+
+	for (const key of Object.keys(mod)) {
+		if (key === "default") continue;
+		if (delegatedSet.has(key) && typeof mod[key] === "function") {
+			// Delegated: each call looks up _m[key], so CJS patches are visible
+			lines.push(`export function ${key}(...a) { return _m["${key}"](...a); }`);
+		} else {
+			// Direct re-export: constants, classes, fd-based functions
+			lines.push(`export const ${key} = _m["${key}"];`);
+		}
+	}
+
+	lines.push("export default _m;");
+	return lines.join("\n");
+}
+
+const FS_SOURCE = generateWrapperSource("fs", FS_DELEGATED);
+const FSP_SOURCE = generateWrapperSource("fs/promises", FSP_DELEGATED);
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export async function resolve(specifier, context, nextResolve) {
+	if (specifier === "node:fs" || specifier === "fs") {
+		return { shortCircuit: true, url: "pi-enclave:fs" };
+	}
+	if (specifier === "node:fs/promises" || specifier === "fs/promises") {
+		return { shortCircuit: true, url: "pi-enclave:fs/promises" };
+	}
+	return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+	if (url === "pi-enclave:fs") {
+		return { shortCircuit: true, format: "module", source: FS_SOURCE };
+	}
+	if (url === "pi-enclave:fs/promises") {
+		return { shortCircuit: true, format: "module", source: FSP_SOURCE };
+	}
+	return nextLoad(url, context);
+}

--- a/packages/enclave/src/tmp-redirect.ts
+++ b/packages/enclave/src/tmp-redirect.ts
@@ -1,0 +1,221 @@
+/**
+ * Redirect /tmp file operations to a shared subdirectory.
+ *
+ * Two layers ensure comprehensive interception:
+ *
+ * 1. **ESM loader hooks** (via module.register): replace node:fs and
+ *    node:fs/promises imports with wrapper modules whose exports delegate
+ *    through the CJS exports object. This makes ESM static named imports
+ *    (e.g. `import { writeFileSync } from "node:fs"`) see CJS-level patches
+ *    for any module loaded AFTER registration.
+ *
+ * 2. **CJS monkey-patch**: rewrites /tmp paths on the actual require("fs")
+ *    and require("fs/promises") exports. The wrapper modules from layer 1
+ *    call through these patched functions.
+ *
+ * Limitation: code that imported node:fs before registration (pi's own
+ * internals, the enclave extension itself) retains original bindings.
+ * This is fine since those modules don't write to /tmp for the agent.
+ */
+
+import { createRequire } from "node:module";
+import { register } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const fsModule = require("node:fs") as typeof import("node:fs");
+const fspModule = require("node:fs/promises") as typeof import("node:fs/promises");
+
+const TMP_PREFIX = "/tmp/";
+
+// ---------------------------------------------------------------------------
+// Path rewriting
+// ---------------------------------------------------------------------------
+
+function makeRewriter(sharedDir: string): (p: unknown) => unknown {
+	return (p: unknown): unknown => {
+		if (typeof p !== "string") return p;
+		if (p === "/tmp") return sharedDir;
+		if (p.startsWith(TMP_PREFIX) && !p.startsWith(`${sharedDir}/`) && p !== sharedDir) {
+			return join(sharedDir, p.slice(TMP_PREFIX.length));
+		}
+		return p;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// CJS monkey-patching
+// ---------------------------------------------------------------------------
+
+type AnyFn = (...args: unknown[]) => unknown;
+
+function wrap1(obj: Record<string, AnyFn>, name: string, rewrite: (p: unknown) => unknown): void {
+	const orig = obj[name];
+	if (typeof orig !== "function") return;
+	obj[name] = function (this: unknown, p: unknown, ...rest: unknown[]) {
+		return orig.call(this, rewrite(p), ...rest);
+	};
+	Object.defineProperty(obj[name], "name", { value: name });
+}
+
+function wrap2(obj: Record<string, AnyFn>, name: string, rewrite: (p: unknown) => unknown): void {
+	const orig = obj[name];
+	if (typeof orig !== "function") return;
+	obj[name] = function (this: unknown, p1: unknown, p2: unknown, ...rest: unknown[]) {
+		return orig.call(this, rewrite(p1), rewrite(p2), ...rest);
+	};
+	Object.defineProperty(obj[name], "name", { value: name });
+}
+
+const SINGLE_PATH_SYNC = [
+	"accessSync",
+	"appendFileSync",
+	"chmodSync",
+	"chownSync",
+	"existsSync",
+	"lchmodSync",
+	"lchownSync",
+	"lstatSync",
+	"lutimesSync",
+	"mkdirSync",
+	"mkdtempSync",
+	"opendirSync",
+	"openSync",
+	"readdirSync",
+	"readFileSync",
+	"readlinkSync",
+	"realpathSync",
+	"rmdirSync",
+	"rmSync",
+	"statSync",
+	"statfsSync",
+	"truncateSync",
+	"unlinkSync",
+	"utimesSync",
+	"writeFileSync",
+	"globSync",
+	"watch",
+	"watchFile",
+	"unwatchFile",
+];
+
+const SINGLE_PATH_ASYNC = [
+	"access",
+	"appendFile",
+	"chmod",
+	"chown",
+	"exists",
+	"lchmod",
+	"lchown",
+	"lstat",
+	"lutimes",
+	"mkdir",
+	"mkdtemp",
+	"open",
+	"opendir",
+	"readdir",
+	"readFile",
+	"readlink",
+	"realpath",
+	"rm",
+	"rmdir",
+	"stat",
+	"statfs",
+	"truncate",
+	"unlink",
+	"utimes",
+	"writeFile",
+	"glob",
+];
+
+const SINGLE_PATH_STREAM = ["createReadStream", "createWriteStream"];
+const TWO_PATH_SYNC = ["copyFileSync", "cpSync", "linkSync", "renameSync", "symlinkSync"];
+const TWO_PATH_ASYNC = ["copyFile", "cp", "link", "rename", "symlink"];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface TmpRedirect {
+	/** The host-side shared directory (mounted at /tmp in the VM). */
+	sharedDir: string;
+	/** Remove the monkey-patches and optionally delete the shared directory. */
+	uninstall(cleanup?: boolean): void;
+}
+
+/**
+ * Install /tmp redirection:
+ * 1. Register ESM loader hooks (intercepts future node:fs imports)
+ * 2. Patch CJS require("fs") exports (path rewriting)
+ * 3. Create the shared directory
+ */
+export function installTmpRedirect(): TmpRedirect {
+	const sharedDir = join("/tmp", `pi-enclave-${process.pid}`);
+
+	const fsAny = fsModule as unknown as Record<string, AnyFn>;
+	const fspAny = fspModule as unknown as Record<string, AnyFn>;
+
+	// Save originals before patching.
+	const origMkdirSync = fsAny.mkdirSync as typeof fsModule.mkdirSync;
+	const origRmSync = fsAny.rmSync as typeof fsModule.rmSync;
+
+	origMkdirSync(sharedDir, { recursive: true });
+
+	// Register ESM loader hooks so future imports of node:fs go through
+	// wrapper modules that delegate to the (now-patched) CJS exports.
+	const hooksPath = join(dirname(fileURLToPath(import.meta.url)), "fs-loader-hooks.mjs");
+	register(pathToFileURL(hooksPath).href, import.meta.url);
+
+	const rewrite = makeRewriter(sharedDir);
+
+	// Save originals for uninstall.
+	const origFs: Record<string, AnyFn> = {};
+	const origFsp: Record<string, AnyFn> = {};
+
+	function save(obj: Record<string, AnyFn>, store: Record<string, AnyFn>, names: string[]) {
+		for (const n of names) {
+			if (typeof obj[n] === "function") store[n] = obj[n];
+		}
+	}
+
+	const allFsNames = [
+		...SINGLE_PATH_SYNC,
+		...SINGLE_PATH_ASYNC,
+		...SINGLE_PATH_STREAM,
+		...TWO_PATH_SYNC,
+		...TWO_PATH_ASYNC,
+	];
+	const allFspNames = [...SINGLE_PATH_ASYNC, ...TWO_PATH_ASYNC];
+
+	save(fsAny, origFs, allFsNames);
+	save(fspAny, origFsp, allFspNames);
+
+	// Patch CJS exports (the wrapper modules from the loader hooks delegate here).
+	for (const n of [...SINGLE_PATH_SYNC, ...SINGLE_PATH_ASYNC, ...SINGLE_PATH_STREAM]) wrap1(fsAny, n, rewrite);
+	for (const n of [...TWO_PATH_SYNC, ...TWO_PATH_ASYNC]) wrap2(fsAny, n, rewrite);
+
+	for (const n of SINGLE_PATH_ASYNC) wrap1(fspAny, n, rewrite);
+	for (const n of TWO_PATH_ASYNC) wrap2(fspAny, n, rewrite);
+
+	return {
+		sharedDir,
+		uninstall(cleanup = true) {
+			for (const [n, fn] of Object.entries(origFs)) fsAny[n] = fn;
+			for (const [n, fn] of Object.entries(origFsp)) fspAny[n] = fn;
+
+			// Note: loader hooks cannot be unregistered (no API for that).
+			// After uninstall the wrapper modules still delegate to the CJS
+			// exports, which are now restored to originals, so the net effect
+			// is transparent.
+
+			if (cleanup) {
+				try {
+					origRmSync(sharedDir, { recursive: true, force: true });
+				} catch {
+					// Best-effort cleanup
+				}
+			}
+		},
+	};
+}

--- a/packages/enclave/src/vm.ts
+++ b/packages/enclave/src/vm.ts
@@ -23,6 +23,7 @@ import {
 import type { GitCredentialDef, ResolvedHostPolicy, ResolvedSecret } from "./config.js";
 import { checkGraphQLPolicy, parseGraphQLBody } from "./graphql.js";
 import { evaluateRequest } from "./policy.js";
+import { type TmpRedirect, installTmpRedirect } from "./tmp-redirect.js";
 
 export interface ExtraMount {
 	path: string;
@@ -56,6 +57,7 @@ export interface EnclaveVMOptions {
 
 export class EnclaveVM {
 	private vm: VM | undefined;
+	private tmpRedirect: TmpRedirect | undefined;
 	private closed = false;
 	private readonly options: EnclaveVMOptions;
 
@@ -230,6 +232,27 @@ export class EnclaveVM {
 			}
 		}
 
+		// Redirect /tmp file operations from host-side extensions into a
+		// dedicated subdirectory and mount it at /tmp in the VM. This makes
+		// files written by extensions (e.g. librarian saving fetched content
+		// to /tmp/pi-librarian/...) visible inside the guest at their
+		// original paths, without exposing all of host /tmp.
+		//
+		// Two layers of interception:
+		// - ESM loader hooks (module.register) replace node:fs imports with
+		//   wrapper modules, catching static named imports in extensions
+		//   loaded after the hooks are registered.
+		// - CJS monkey-patches on require("fs") do the actual path rewriting.
+		//
+		// Not intercepted: code that imported node:fs before hook
+		// registration (pi internals, this extension), and child processes.
+		// Users who need full /tmp visibility can add mounts = ["/tmp"]
+		// in their enclave config.
+		if (!mounts["/tmp"]) {
+			this.tmpRedirect = installTmpRedirect();
+			mounts["/tmp"] = new RealFSProvider(this.tmpRedirect.sharedDir);
+		}
+
 		// Create and start VM
 		this.vm = await VM.create({
 			httpHooks,
@@ -301,6 +324,10 @@ export class EnclaveVM {
 	async close(): Promise<void> {
 		if (this.closed) return;
 		this.closed = true;
+		if (this.tmpRedirect) {
+			this.tmpRedirect.uninstall();
+			this.tmpRedirect = undefined;
+		}
 		if (this.vm) {
 			await this.vm.close();
 			this.vm = undefined;

--- a/packages/enclave/test/tmp-redirect.test.ts
+++ b/packages/enclave/test/tmp-redirect.test.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type TmpRedirect, installTmpRedirect } from "../src/tmp-redirect.js";
+
+describe("tmp-redirect", () => {
+	let redirect: TmpRedirect;
+
+	beforeEach(() => {
+		redirect = installTmpRedirect();
+	});
+
+	afterEach(() => {
+		redirect.uninstall(true);
+	});
+
+	// -----------------------------------------------------------------------
+	// CJS-level patching (module object access)
+	// -----------------------------------------------------------------------
+
+	it("redirects sync writes via module object", () => {
+		fs.mkdirSync("/tmp/test-redirect-sync", { recursive: true });
+		fs.writeFileSync("/tmp/test-redirect-sync/hello.txt", "world");
+
+		const realPath = join(redirect.sharedDir, "test-redirect-sync/hello.txt");
+		expect(fs.existsSync(realPath)).toBe(true);
+		expect(fs.readFileSync("/tmp/test-redirect-sync/hello.txt", "utf8")).toBe("world");
+	});
+
+	it("redirects async writes via module object", async () => {
+		await fsp.mkdir("/tmp/test-redirect-async", { recursive: true });
+		await fsp.writeFile("/tmp/test-redirect-async/data.txt", "async-content");
+
+		const content = await fsp.readFile("/tmp/test-redirect-async/data.txt", "utf8");
+		expect(content).toBe("async-content");
+
+		const realPath = join(redirect.sharedDir, "test-redirect-async/data.txt");
+		expect(fs.existsSync(realPath)).toBe(true);
+	});
+
+	it("redirects mkdtempSync via module object", () => {
+		const tmpDir = fs.mkdtempSync("/tmp/test-mkdtemp-");
+		expect(tmpDir.startsWith(redirect.sharedDir)).toBe(true);
+		fs.writeFileSync(join(tmpDir, "file.txt"), "in-mkdtemp");
+		expect(fs.readFileSync(join(tmpDir, "file.txt"), "utf8")).toBe("in-mkdtemp");
+	});
+
+	it("redirects two-path operations (rename) via module object", async () => {
+		await fsp.mkdir("/tmp/test-rename", { recursive: true });
+		await fsp.writeFile("/tmp/test-rename/old.txt", "rename-me");
+		await fsp.rename("/tmp/test-rename/old.txt", "/tmp/test-rename/new.txt");
+
+		expect(fs.existsSync(join(redirect.sharedDir, "test-rename/new.txt"))).toBe(true);
+		const content = await fsp.readFile("/tmp/test-rename/new.txt", "utf8");
+		expect(content).toBe("rename-me");
+	});
+
+	it("redirects copyFile via module object", async () => {
+		await fsp.mkdir("/tmp/test-copy", { recursive: true });
+		await fsp.writeFile("/tmp/test-copy/src.txt", "copy-me");
+		await fsp.copyFile("/tmp/test-copy/src.txt", "/tmp/test-copy/dst.txt");
+
+		const content = await fsp.readFile("/tmp/test-copy/dst.txt", "utf8");
+		expect(content).toBe("copy-me");
+	});
+
+	it("redirects createWriteStream / createReadStream", async () => {
+		fs.mkdirSync("/tmp/test-stream", { recursive: true });
+
+		await new Promise<void>((resolve, reject) => {
+			const ws = fs.createWriteStream("/tmp/test-stream/out.txt");
+			ws.write("streamed");
+			ws.end();
+			ws.on("finish", resolve);
+			ws.on("error", reject);
+		});
+
+		const chunks: Buffer[] = [];
+		await new Promise<void>((resolve, reject) => {
+			const rs = fs.createReadStream("/tmp/test-stream/out.txt");
+			rs.on("data", (chunk) => chunks.push(chunk as Buffer));
+			rs.on("end", resolve);
+			rs.on("error", reject);
+		});
+		expect(Buffer.concat(chunks).toString()).toBe("streamed");
+	});
+
+	// -----------------------------------------------------------------------
+	// Guard and edge cases
+	// -----------------------------------------------------------------------
+
+	it("does not double-rewrite paths already under the shared dir", () => {
+		fs.mkdirSync(join(redirect.sharedDir, "direct"), { recursive: true });
+		fs.writeFileSync(join(redirect.sharedDir, "direct/file.txt"), "direct-write");
+		expect(fs.readFileSync(join(redirect.sharedDir, "direct/file.txt"), "utf8")).toBe("direct-write");
+	});
+
+	it("handles bare /tmp path", () => {
+		expect(fs.existsSync("/tmp")).toBe(true);
+	});
+
+	it("does not affect non-/tmp paths", () => {
+		const testDir = fs.mkdtempSync(join(redirect.sharedDir, "non-tmp-"));
+		fs.writeFileSync(join(testDir, "ok.txt"), "not-redirected");
+		expect(fs.readFileSync(join(testDir, "ok.txt"), "utf8")).toBe("not-redirected");
+	});
+
+	it("ignores non-string paths", () => {
+		expect(() => {
+			try {
+				fs.readFileSync(Buffer.from("/tmp/buffer-path") as unknown as string);
+			} catch (e: unknown) {
+				if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+				throw e;
+			}
+		}).not.toThrow();
+	});
+
+	it("restores original functions on uninstall", () => {
+		redirect.uninstall(true);
+
+		const testPath = `/tmp/pi-enclave-uninstall-test-${process.pid}`;
+		try {
+			fs.writeFileSync(testPath, "real-tmp");
+			expect(fs.readFileSync(testPath, "utf8")).toBe("real-tmp");
+		} finally {
+			try {
+				fs.rmSync(testPath);
+			} catch {
+				// cleanup
+			}
+		}
+
+		// Reinstall for afterEach cleanup
+		redirect = installTmpRedirect();
+	});
+
+	it("handles reinstall after uninstall (VM restart)", () => {
+		// Simulate /enclave restart: uninstall, then install fresh
+		const oldShared = redirect.sharedDir;
+		fs.mkdirSync(join(oldShared, "before-restart"), { recursive: true });
+		fs.writeFileSync(join(oldShared, "before-restart/data.txt"), "old-data");
+
+		redirect.uninstall(true);
+		expect(fs.existsSync(oldShared)).toBe(false);
+
+		redirect = installTmpRedirect();
+		// New install works, old data is gone (clean slate)
+		expect(fs.existsSync("/tmp/before-restart/data.txt")).toBe(false);
+
+		// New writes work
+		fs.mkdirSync("/tmp/after-restart", { recursive: true });
+		fs.writeFileSync("/tmp/after-restart/data.txt", "new-data");
+		expect(fs.readFileSync("/tmp/after-restart/data.txt", "utf8")).toBe("new-data");
+	});
+
+	it("leaves paths outside /tmp untouched", () => {
+		// /var should resolve normally (not rewritten)
+		expect(() => fs.statSync("/var")).not.toThrow();
+		// A non-existent path outside /tmp should fail with its original path
+		try {
+			fs.readFileSync("/var/nonexistent-redirect-test");
+		} catch (e: unknown) {
+			expect((e as NodeJS.ErrnoException).code).toBe("ENOENT");
+			expect((e as NodeJS.ErrnoException).message).not.toContain(redirect.sharedDir);
+		}
+	});
+
+	it("cleans up shared directory on uninstall", () => {
+		const sharedDir = redirect.sharedDir;
+		fs.mkdirSync(join(sharedDir, "cleanup-test"), { recursive: true });
+		fs.writeFileSync(join(sharedDir, "cleanup-test/file.txt"), "to-be-cleaned");
+
+		redirect.uninstall(true);
+		// After uninstall, patched fs.existsSync still delegates to the
+		// restored original (loader hooks are still active but the CJS
+		// exports are back to normal), so this checks the real filesystem.
+		expect(fs.existsSync(sharedDir)).toBe(false);
+
+		redirect = installTmpRedirect();
+	});
+});

--- a/packages/enclave/tsup.config.ts
+++ b/packages/enclave/tsup.config.ts
@@ -1,3 +1,4 @@
+import { cpSync } from "node:fs";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
@@ -6,4 +7,8 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	external: ["@mariozechner/pi-coding-agent", "@earendil-works/gondolin"],
+	onSuccess: async () => {
+		// Copy the ESM loader hooks file to dist (plain JS, not processed by tsup)
+		cpSync("src/fs-loader-hooks.mjs", "dist/fs-loader-hooks.mjs");
+	},
 });


### PR DESCRIPTION
Add two-layer interception for /tmp file operations so that files written by host-side extensions (e.g. librarian saving to /tmp/pi-librarian/...) are visible inside the VM at their original paths, without exposing the full host /tmp.

Layer 1: ESM loader hooks (module.register) replace node:fs and node:fs/promises imports with wrapper modules that delegate through the CJS exports object. This catches static ESM named imports in extensions loaded after hook registration.

Layer 2: CJS monkey-patches on require('fs') do the actual /tmp path rewriting, redirecting into a per-process shared directory that is mounted at /tmp in the VM.

Not intercepted: pi internals (imported before registration) and child processes. Users who need full /tmp visibility can add mounts = ["/tmp"] in their enclave config.

add changeset for tmp-redirect