### PR TITLE
fix(pi-jujutsu): show error details on snapshot failure

### DIFF
--- a/.changeset/snapshot-error-messages.md
+++ b/.changeset/snapshot-error-messages.md
@@ -1,0 +1,5 @@
+---
+"pi-jujutsu": patch
+---
+
+Show jj error details in snapshot failure notifications instead of a generic message.

--- a/packages/jujutsu/src/format.ts
+++ b/packages/jujutsu/src/format.ts
@@ -45,10 +45,12 @@ export function colorizeFileLine(line: string, theme: ThemeFg): string {
 	return prefix + coloredBar;
 }
 
-/** Format and colorize the summary line into a compact form: "2 files (+49, -11)" */
-export function formatSummaryLine(line: string, theme: ThemeFg): string {
-	const match = line.match(/(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/);
-	if (!match) return line;
+const SUMMARY_RE = /(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/;
+
+/** Format a jj diff --stat summary line into compact colored form: "2 files (+49, -11)" */
+function formatStats(summaryLine: string, theme: ThemeFg): string | null {
+	const match = summaryLine.match(SUMMARY_RE);
+	if (!match) return null;
 
 	const files = match[1];
 	const ins = match[2] ? Number.parseInt(match[2], 10) : 0;
@@ -60,6 +62,11 @@ export function formatSummaryLine(line: string, theme: ThemeFg): string {
 
 	const counts = parts.length > 0 ? ` (${parts.join(", ")})` : "";
 	return `${files} file${files === "1" ? "" : "s"}${counts}`;
+}
+
+/** Format and colorize the summary line into a compact form: "2 files (+49, -11)" */
+export function formatSummaryLine(line: string, theme: ThemeFg): string {
+	return formatStats(line, theme) ?? line;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,23 +96,10 @@ export function buildWidgetLines(wc: WcStats, theme: ThemeFg): string[] {
 
 /** Format a compact one-liner for the widget when @ is empty: "@- description · 2 files (+49, -11)" */
 export function formatParentOneLiner(description: string, summaryLine: string, theme: ThemeFg): string {
-	const match = summaryLine.match(/(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/);
-
-	let stats = "";
-	if (match) {
-		const files = match[1];
-		const ins = match[2] ? Number.parseInt(match[2], 10) : 0;
-		const del = match[3] ? Number.parseInt(match[3], 10) : 0;
-		const parts: string[] = [];
-		if (ins > 0) parts.push(theme.fg("toolDiffAdded", `+${ins}`));
-		if (del > 0) parts.push(theme.fg("toolDiffRemoved", `-${del}`));
-		const counts = parts.length > 0 ? ` (${parts.join(", ")})` : "";
-		stats = `${files} file${files === "1" ? "" : "s"}${counts}`;
-	}
-
+	const stats = formatStats(summaryLine, theme);
 	const prefix = theme.fg("accent", "@-");
 	const sep = stats ? theme.fg("muted", " · ") : "";
-	return `${prefix} ${description}${sep}${stats}`;
+	return `${prefix} ${description}${sep}${stats ?? ""}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/jujutsu/src/index.ts
+++ b/packages/jujutsu/src/index.ts
@@ -63,9 +63,10 @@ export default function (pi: ExtensionAPI) {
 		return result.stdout.split("\n").filter(Boolean).length;
 	}
 
-	async function snapshot(): Promise<boolean> {
+	async function snapshot(): Promise<{ ok: boolean; error?: string }> {
 		const result = await pi.exec("jj", ["util", "snapshot"], { timeout: 10000 });
-		return result.code === 0;
+		if (result.code === 0) return { ok: true };
+		return { ok: false, error: (result.stderr || result.stdout).trim() };
 	}
 
 	/** Get diff stat for a revision. Defaults to @ (working copy). Respects terminal width via COLUMNS. */
@@ -201,9 +202,13 @@ export default function (pi: ExtensionAPI) {
 	async function snapshotAndRefreshWidget(ctx: ExtensionContext): Promise<void> {
 		if (!isJjRepo) return;
 
-		const ok = await snapshot();
+		const { ok, error } = await snapshot();
 		if (!ok) {
-			if (ctx.hasUI) ctx.ui.notify("pi-jujutsu: snapshot failed", "error");
+			if (ctx.hasUI) {
+				const firstLine = error?.split("\n")[0] || "";
+				const msg = firstLine ? `pi-jujutsu: snapshot failed: ${firstLine}` : "pi-jujutsu: snapshot failed";
+				ctx.ui.notify(msg, "error");
+			}
 			return;
 		}
 


### PR DESCRIPTION
When `jj util snapshot` fails, the notification now shows the first line of jj's error output (e.g. "Internal error: Failed to commit new operation") instead of a generic "snapshot failed".

Also deduplicates the summary line regex between `formatSummaryLine` and `formatParentOneLiner` into a shared `formatStats` helper.