### PR TITLE
fix(pi-bash-bg): correct README install command

### DIFF
--- a/.changeset/fix-bash-bg-readme-install.md
+++ b/.changeset/fix-bash-bg-readme-install.md
@@ -1,0 +1,5 @@
+---
+"pi-bash-bg": patch
+---
+
+Fix the README install command to use the correct `npm:` package prefix for `pi install`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,7 @@ yarn lint:fix       # biome check --write
 ```
 
 After completing changes, include a changeset file for affected packages (`yarn changeset`). See `DEVELOPMENT.md` for the release workflow.
+
+## Gotchas
+
+- Package README install examples should use `pi install npm:<package-name>` for npm packages.

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -25,7 +25,7 @@ It can then `cat` the log file or `kill` the PID.
 ## Install
 
 ```bash
-pi install pi-bash-bg
+pi install npm:pi-bash-bg
 ```
 
 ## How it works


### PR DESCRIPTION
## Summary
- fix the `pi-bash-bg` README install command to use the required `npm:` prefix
- add a short AGENTS.md note so package README install examples use `pi install npm:<package-name>`
- include a changeset for the README fix

## Testing
- not run, docs-only change