### PR TITLE
fix(bash-bg): stop overriding the built-in bash tool

### DIFF
--- a/.changeset/bash-bg-fix-resume-cwd.md
+++ b/.changeset/bash-bg-fix-resume-cwd.md
@@ -1,0 +1,5 @@
+---
+"pi-bash-bg": patch
+---
+
+Stop overriding the built-in bash tool so resumed sessions run bash in the session's cwd.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ yarn lint           # biome check
 yarn lint:fix       # biome check --write
 ```
 
-After completing changes, include a changeset file for affected packages (`yarn changeset`). See `DEVELOPMENT.md` for the release workflow.
+After completing changes, include a changeset file for affected packages (`yarn changeset`). Keep changeset summaries to a single line whenever possible; users see them rendered in the CHANGELOG, so be concise. See `DEVELOPMENT.md` for the release workflow.
 
 ## Gotchas
 

--- a/packages/bash-bg/README.md
+++ b/packages/bash-bg/README.md
@@ -8,7 +8,7 @@ The bash tool pipes stdout/stderr from the spawned shell. When a command backgro
 
 ## Solution
 
-This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), appends background-job guidance to the bash tool description, and rewrites the command to:
+This extension intercepts bash tool calls, parses the command with [@aliou/sh](https://github.com/nicolo-ribaudo/sh) to detect background processes (`stmt.background === true`), and rewrites the command to:
 
 1. **Redirect output** to temp log files with human-readable names based on the command label, so background processes release the pipes
 2. **Add `disown`** to detach from job control (if not already present)
@@ -77,10 +77,6 @@ echo "[bg] pid=$! label=npm start log=/tmp/pi-bg-npm-start-3.log"
 ### Existing disown
 
 If the command already has `disown` after the `&`, no duplicate is added.
-
-### Bash tool description
-
-The extension appends a short background-job summary to the bash tool description, so the model sees it directly in tool metadata.
 
 ## Supported patterns
 

--- a/packages/bash-bg/src/index.ts
+++ b/packages/bash-bg/src/index.ts
@@ -15,23 +15,14 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { createBashTool, isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import { detectBackground } from "./detect.js";
 import { rewriteCommand } from "./rewrite.js";
 
 export { detectBackground, type BgStatement, type DetectResult } from "./detect.js";
 export { rewriteCommand, findBgOperatorPositions, type BgProcessInfo, type RewriteResult } from "./rewrite.js";
 
-const BASH_DESCRIPTION_APPENDIX =
-	"Background jobs continue running after the command returns. Their output is captured to a log file even without explicit redirection. The PID and log path will be returned.";
-
 export default function (pi: ExtensionAPI) {
-	const bashTool = createBashTool(process.cwd());
-	pi.registerTool({
-		...bashTool,
-		description: `${bashTool.description} ${BASH_DESCRIPTION_APPENDIX}`,
-	});
-
 	pi.on("tool_call", async (event) => {
 		if (!isToolCallEventType("bash", event)) return;
 

--- a/packages/bash-bg/test/index.test.ts
+++ b/packages/bash-bg/test/index.test.ts
@@ -1,25 +1,86 @@
-import type { ExtensionAPI, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolCallEvent, ToolCallEventResult, ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import extension from "../src/index.js";
 
+type ToolCallHandler = (
+	event: ToolCallEvent,
+	ctx: unknown,
+) => Promise<ToolCallEventResult | undefined> | ToolCallEventResult | undefined;
+
+function loadExtension() {
+	const tools: ToolDefinition[] = [];
+	let toolCallHandler: ToolCallHandler | undefined;
+	const pi = {
+		registerTool: vi.fn((tool: ToolDefinition) => {
+			tools.push(tool);
+		}),
+		on: vi.fn((event: string, handler: ToolCallHandler) => {
+			if (event === "tool_call") toolCallHandler = handler;
+		}),
+	} as unknown as ExtensionAPI;
+
+	extension(pi);
+
+	return { pi, tools, toolCallHandler };
+}
+
 describe("pi-bash-bg extension", () => {
-	it("appends background job guidance to the bash tool description", () => {
-		const tools: ToolDefinition[] = [];
-		const pi = {
-			registerTool(tool) {
-				tools.push(tool);
-			},
-			on: vi.fn(),
-		} as unknown as ExtensionAPI;
+	it("does not override the built-in bash tool", () => {
+		// Replacing the built-in bash tool would force a fixed cwd captured at
+		// extension load time, which breaks the cwd of resumed sessions.
+		const { pi, tools } = loadExtension();
+		expect(tools).toHaveLength(0);
+		expect(pi.registerTool).not.toHaveBeenCalled();
+	});
 
-		extension(pi);
+	it("registers a tool_call handler", () => {
+		const { pi, toolCallHandler } = loadExtension();
+		expect(pi.on).toHaveBeenCalledWith("tool_call", expect.any(Function));
+		expect(toolCallHandler).toBeDefined();
+	});
 
-		const bashTool = tools.find((tool) => tool.name === "bash");
-		expect(bashTool).toBeDefined();
-		expect(bashTool?.description).toContain("Background jobs continue running after the command returns.");
-		expect(bashTool?.description).toContain(
-			"Their output is captured to a log file even without explicit redirection.",
-		);
-		expect(bashTool?.description).toContain("The PID and log path will be returned.");
+	it("rewrites bash commands that contain background statements", async () => {
+		const { toolCallHandler } = loadExtension();
+		const event: ToolCallEvent = {
+			type: "tool_call",
+			toolName: "bash",
+			toolCallId: "id",
+			input: { command: "sleep 300 &" },
+		};
+
+		await toolCallHandler!(event, {});
+
+		const rewritten = (event.input as { command: string }).command;
+		expect(rewritten).not.toBe("sleep 300 &");
+		expect(rewritten).toContain("disown");
+		expect(rewritten).toContain("[bg]");
+	});
+
+	it("leaves non-background bash commands untouched", async () => {
+		const { toolCallHandler } = loadExtension();
+		const event: ToolCallEvent = {
+			type: "tool_call",
+			toolName: "bash",
+			toolCallId: "id",
+			input: { command: "echo hi && ls" },
+		};
+
+		await toolCallHandler!(event, {});
+
+		expect((event.input as { command: string }).command).toBe("echo hi && ls");
+	});
+
+	it("ignores non-bash tool calls", async () => {
+		const { toolCallHandler } = loadExtension();
+		const event: ToolCallEvent = {
+			type: "tool_call",
+			toolName: "read",
+			toolCallId: "id",
+			input: { path: "foo &" },
+		};
+
+		await toolCallHandler!(event, {});
+
+		expect((event.input as { path: string }).path).toBe("foo &");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes a cwd-mismatch bug in resumed pi sessions caused by `pi-bash-bg` overriding the built-in bash tool with one whose cwd was captured at extension-load time.

The previous version did:

```ts
const bashTool = createBashTool(process.cwd());   // snapshot at load
pi.registerTool({ ...bashTool, description: ... }); // overrides built-in
```

`process.cwd()` is the launcher's cwd at extension-load time, not the resumed session's cwd. The cwd was baked into the spawn closure, so after `pi --resume` from a different directory, bash commands kept running in the launcher's directory while the rest of pi (including the footer) tracked the session's cwd.

The extension only ever needed to rewrite background commands; the `registerTool` call existed to attach a description appendix. Dropping it lets pi's built-in bash tool (which is wired to `AgentSession._cwd`) execute the command, and the `tool_call` handler still mutates `event.input.command` in place to perform the rewrite.

## Changes

- `packages/bash-bg/src/index.ts`: remove `registerTool` and the `createBashTool` import; keep only the `tool_call` rewrite.
- `packages/bash-bg/test/index.test.ts`: replace the description-appendix test with regression tests that assert the extension does not call `registerTool`, that it registers a `tool_call` handler, and that the handler rewrites bg commands while leaving non-bg / non-bash calls alone.
- `packages/bash-bg/README.md`: drop the description-appendix mentions.
- `.changeset/bash-bg-fix-resume-cwd.md`: patch entry.
- `AGENTS.md`: small guidance update asking for one-line changeset summaries.

## Trade-off

The bash tool description no longer carries a "background jobs continue running…" hint to the model. The rewritten command's `[bg] pid=... log=...` output is self-explanatory in practice, and is well-aligned with how bash backgrounding is conventionally communicated.

## Context

Related upstream issue: https://github.com/badlogic/pi-mono/issues/4006
