### PR TITLE
fix(budget-model): preserve auth headers; add modelOverride escape hatch (supersedes #41)

### DIFF
--- a/.changeset/align-pi-versions.md
+++ b/.changeset/align-pi-versions.md
@@ -1,0 +1,12 @@
+---
+"pi-bash-bg": patch
+"pi-bash-trim": patch
+"pi-desktop-notify": patch
+"pi-enclave": patch
+"pi-jujutsu": patch
+"pi-no-soft-cursor": patch
+---
+
+Align `@mariozechner/pi-coding-agent` (and `@mariozechner/pi-tui` for `pi-no-soft-cursor`) `devDependency` to `^0.63.0`.
+
+`devDependency`-only update; no runtime change. Published `dist/*.d.ts` may reference newer upstream types from pi 0.63 (e.g. the `signal` property on `ExtensionContext`), so consumers writing extensions against these packages should be on pi ≥ 0.63 to match. Required to keep `tsup --dts` working alongside `pi-budget-model`, which now depends on the 0.63 registry API.

--- a/.changeset/budget-model-override-with-auth.md
+++ b/.changeset/budget-model-override-with-auth.md
@@ -1,0 +1,24 @@
+---
+"pi-budget-model": minor
+---
+
+Allow supplying auth credentials directly via the `modelOverride` option.
+
+`modelOverride` now accepts an object form in addition to the existing
+`"provider/model-id"` string. The object form skips the registry's auth
+pipeline entirely; the registry is only consulted to resolve the model
+metadata via `find()`. This is an escape hatch for when the registry's
+auth resolution misbehaves for a given provider.
+
+```ts
+findBudgetModel(ctx, {
+  modelOverride: {
+    model: "openai/gpt-4o-mini",
+    auth: { apiKey: process.env.OPENAI_API_KEY },
+  },
+});
+```
+
+The string form is unchanged. A new `BudgetModelAuth` valibot schema is
+exported and reusable as the auth shape across `findBudgetModel`'s result
+and the override option.

--- a/.changeset/budget-model-preserve-auth-headers.md
+++ b/.changeset/budget-model-preserve-auth-headers.md
@@ -1,0 +1,48 @@
+---
+"pi-budget-model": major
+"pi-safeguard": patch
+---
+
+Preserve auth headers from `getApiKeyAndHeaders` so header-authenticated providers work.
+
+The previous wrapper extracted only `auth.apiKey` from the registry's
+`getApiKeyAndHeaders` result and discarded `auth.headers`. Providers that
+authenticate via headers (e.g. an out-of-band `Authorization` header, or AWS
+Bedrock with SDK-resolved credentials) were rejected during selection because
+they returned `{ ok: true, apiKey: undefined, headers: {...} }` and the wrapper
+gated on `apiKey` truthiness. They are now selected and their headers are
+forwarded to `pi-ai`'s `completeSimple`/`stream` (which already accepts
+`headers` on its options object).
+
+`pi-safeguard` is updated to forward the new auth shape; no consumer-visible
+change.
+
+## Migration guide (BREAKING)
+
+`BudgetModel` now has a nested `auth` field instead of a flat `apiKey`:
+
+```ts
+// before
+interface BudgetModel { model: Model<Api>; apiKey: string }
+
+// after
+interface BudgetModel { model: Model<Api>; auth: BudgetModelAuth }
+type BudgetModelAuth = { apiKey?: string; headers?: Record<string, string> }
+```
+
+Update consumers that read `apiKey` directly:
+
+```diff
+ const judge = await findBudgetModel(ctx);
+-await completeSimple(judge.model, ctx, { apiKey: judge.apiKey, signal });
++await completeSimple(judge.model, ctx, { ...judge.auth, signal });
+```
+
+If you can't switch to spreading, read `judge.auth.apiKey` (note: now
+`string | undefined`, since header-only providers return `auth` without an
+`apiKey`).
+
+The minimum required version of `@mariozechner/pi-coding-agent` and
+`@mariozechner/pi-ai` is now `0.63.0` (for the `getApiKeyAndHeaders` registry
+method and the `headers` field on `StreamOptions`). The `peerDependencies`
+range has been tightened to `>=0.63.0` accordingly.

--- a/packages/bash-bg/package.json
+++ b/packages/bash-bg/package.json
@@ -42,7 +42,7 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/bash-trim/package.json
+++ b/packages/bash-trim/package.json
@@ -42,7 +42,7 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/budget-model/README.md
+++ b/packages/budget-model/README.md
@@ -13,29 +13,44 @@ npm install pi-budget-model
 ## Usage
 
 ```typescript
+import { completeSimple } from "@mariozechner/pi-ai";
 import { findBudgetModel, NoBudgetModelError } from "pi-budget-model";
 
 // Simple — cheapest in same provider, latest major version
-const { model, apiKey } = await findBudgetModel(ctx);
+const { model, auth } = await findBudgetModel(ctx);
 
-// Cross-provider — cheapest across all providers with an API key
-const { model, apiKey } = await findBudgetModel(ctx, {
+// `auth` is `{ apiKey?: string; headers?: Record<string, string> }`, ready to
+// spread into pi-ai's stream/completeSimple options.
+await completeSimple(model, ctx, { ...auth, signal });
+
+// Cross-provider — cheapest across all providers with usable auth
+const { model, auth } = await findBudgetModel(ctx, {
   strategy: "any-provider",
 });
 
 // Include previous major version (often much cheaper)
-const { model, apiKey } = await findBudgetModel(ctx, {
+const { model, auth } = await findBudgetModel(ctx, {
   majorVersions: 2,    // latest + previous major version
   costRatio: 0.5,      // must be ≤ half the active model's cost
 });
 
 // Pin a specific model, skip auto-selection
-const { model, apiKey } = await findBudgetModel(ctx, {
+const { model, auth } = await findBudgetModel(ctx, {
   modelOverride: "anthropic/claude-haiku-4-5",
 });
 
+// Pin a model AND supply credentials directly, bypassing the registry's auth
+// resolution. Use as an escape hatch when the registry's auth pipeline
+// misbehaves for your provider.
+const { model, auth } = await findBudgetModel(ctx, {
+  modelOverride: {
+    model: "openai/gpt-4o-mini",
+    auth: { apiKey: process.env.OPENAI_API_KEY },
+  },
+});
+
 // Only free models
-const { model, apiKey } = await findBudgetModel(ctx, {
+const { model, auth } = await findBudgetModel(ctx, {
   costRatio: 0,
 });
 ```
@@ -67,7 +82,7 @@ When the active model is already the cheapest (like Haiku 4.5), you can widen th
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `modelOverride` | `"provider/model-id"` | — | Pin a specific model, bypassing auto-selection entirely |
+| `modelOverride` | `"provider/model-id"` \| `{ model, auth }` | — | Pin a specific model, bypassing auto-selection entirely |
 | `strategy` | `"same-provider"` \| `"any-provider"` | `"same-provider"` | Where to search for budget models |
 | `costRatio` | `0`–`1` | `0.5` | Max cost as fraction of active model (0 = free only) |
 | `majorVersions` | `0`, `1`, `2`, ... | `1` | How many major versions to search (1 = latest, 2 = latest + previous, 0 = all) |
@@ -76,9 +91,12 @@ Options are validated at runtime with [valibot](https://valibot.dev). Invalid va
 
 ### `modelOverride`
 
-When set, **all other options are ignored**. The model is resolved directly from the registry by provider and ID — no strategy, cost ratio, or version filtering applies. Throws `NoBudgetModelError` if the model doesn't exist or has no API key.
+When set, **all other options are ignored**. The model is resolved directly from the registry by provider and ID — no strategy, cost ratio, or version filtering applies. Throws `NoBudgetModelError` if the model doesn't exist in the registry.
 
-This is useful for pinning a known-good model in config files, or for testing.
+Two forms:
+
+- **String** `"provider/model-id"`: registry resolves both the model metadata and the auth credentials. Use this for pinning a known-good model in config files or for testing.
+- **Object** `{ model: "provider/model-id", auth: { apiKey?, headers? } }`: registry resolves the model metadata via `find()`, but auth is taken straight from the option — the registry's auth pipeline (`getApiKeyAndHeaders`) is not invoked. Use this as an escape hatch when the registry's auth resolution misbehaves for your provider, or to inject credentials from a non-pi source.
 
 ### Reusable options schema
 
@@ -104,7 +122,7 @@ For `same-provider` (default):
 3. Find the cheapest model(s) by input cost
 4. Verify the cheapest is within the cost ratio vs the active model
 5. Among ties: higher version numbers win, aliases preferred over dated snapshots
-6. Return the first candidate with an available API key
+6. Return the first candidate the registry can authenticate (any `ok: true` result, including header-only and SDK-resolved auth)
 
 For `any-provider`: same steps but across all providers, grouped independently per provider then merged.
 
@@ -114,7 +132,7 @@ Throws `NoBudgetModelError` when no suitable model is found. The error includes 
 
 ```typescript
 try {
-  const { model, apiKey } = await findBudgetModel(ctx);
+  const { model, auth } = await findBudgetModel(ctx);
 } catch (err) {
   if (err instanceof NoBudgetModelError) {
     err.reason;          // why it failed

--- a/packages/budget-model/package.json
+++ b/packages/budget-model/package.json
@@ -33,8 +33,8 @@
     "valibot": "^1.2.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-ai": ">=0.63.0",
+    "@mariozechner/pi-coding-agent": ">=0.63.0"
   },
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.63.0",

--- a/packages/budget-model/package.json
+++ b/packages/budget-model/package.json
@@ -37,8 +37,8 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-ai": "^0.57.0",
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-ai": "^0.63.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/budget-model/src/index.ts
+++ b/packages/budget-model/src/index.ts
@@ -66,7 +66,17 @@ export const BudgetModelOptions = v.object({
 });
 export type BudgetModelOptions = v.InferOutput<typeof BudgetModelOptions>;
 
-/** A model selected for a background task, plus the auth material needed to call it. */
+/**
+ * A model selected for a background task, plus the auth material needed to call it.
+ *
+ * `auth` is the same shape `pi-ai`'s `StreamOptions` accepts. The intended call
+ * pattern is to spread it directly:
+ *
+ * ```ts
+ * const { model, auth } = await findBudgetModel(ctx);
+ * await completeSimple(model, ctx, { ...auth, signal, maxTokens });
+ * ```
+ */
 export interface BudgetModel {
 	model: Model<Api>;
 	auth: BudgetModelAuth;
@@ -131,8 +141,18 @@ export class NoBudgetModelError extends Error {
 /**
  * Find the cheapest available model for background tasks.
  *
+ * If `options.modelOverride` is set, selection is skipped:
+ * - String form `"provider/model-id"`: registry resolves both model and auth.
+ * - Object form `{ model, auth }`: registry resolves only the model metadata
+ *   via `find()`; auth is taken from the option, bypassing the registry's
+ *   auth pipeline. Useful as an escape hatch when registry auth misbehaves.
+ *
+ * Otherwise the configured `strategy` (`"same-provider"` or `"any-provider"`)
+ * walks candidate models cheapest-first, gated by `costRatio` against the
+ * active model, and returns the first candidate the registry can authenticate.
+ *
  * @param ctx - Extension context
- * @param options - Strategy, cost ratio, and major version depth (validated at runtime)
+ * @param options - Strategy, cost ratio, major version depth, and optional override (validated at runtime)
  * @throws NoBudgetModelError if no suitable model is found
  */
 export async function findBudgetModel(ctx: ExtensionContext, options?: BudgetModelOptions): Promise<BudgetModel> {

--- a/packages/budget-model/src/index.ts
+++ b/packages/budget-model/src/index.ts
@@ -24,6 +24,20 @@ import * as v from "valibot";
 export const ModelStrategy = v.picklist(["same-provider", "any-provider"]);
 export type ModelStrategy = v.InferOutput<typeof ModelStrategy>;
 
+/**
+ * Auth material for calling a model, mirroring the success branch of the model
+ * registry's `getApiKeyAndHeaders` result and the fields `pi-ai`'s `StreamOptions`
+ * accepts. Both fields are optional: most providers use `apiKey`, some use `headers`
+ * (e.g. an out-of-band `Authorization` header), and some use neither (e.g. AWS
+ * Bedrock with SDK-resolved credentials). Spread into `completeSimple`/`stream`
+ * options as `{ ...auth, signal, ... }`.
+ */
+export const BudgetModelAuth = v.object({
+	apiKey: v.optional(v.string()),
+	headers: v.optional(v.record(v.string(), v.string())),
+});
+export type BudgetModelAuth = v.InferOutput<typeof BudgetModelAuth>;
+
 export const BudgetModelOptions = v.object({
 	/** Pin a specific model, bypassing auto-selection entirely. Format: "provider/model-id". */
 	modelOverride: v.optional(v.pipe(v.string(), v.regex(/^[^/]+\/.+$/, 'must be "provider/model-id"'))),
@@ -34,9 +48,10 @@ export const BudgetModelOptions = v.object({
 });
 export type BudgetModelOptions = v.InferOutput<typeof BudgetModelOptions>;
 
+/** A model selected for a background task, plus the auth material needed to call it. */
 export interface BudgetModel {
 	model: Model<Api>;
-	apiKey: string;
+	auth: BudgetModelAuth;
 }
 
 /** A model candidate found during search — may not have passed all checks. */
@@ -121,9 +136,18 @@ export async function findBudgetModel(ctx: ExtensionContext, options?: BudgetMod
 	return findSameProvider(ctx, activeModel, opts.costRatio, opts.majorVersions);
 }
 
-async function getApiKey(ctx: ExtensionContext, model: Model<Api>): Promise<string | undefined> {
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-	return auth.ok ? auth.apiKey : undefined;
+/**
+ * Resolve auth for a model via the registry. Returns null if the registry reported failure.
+ *
+ * A successful resolution may have `apiKey`, `headers`, both, or neither populated
+ * (the last case being valid for providers that authenticate via ambient SDK credentials).
+ * We treat any `ok: true` result as usable — the downstream provider decides whether the
+ * material is sufficient.
+ */
+async function resolveAuth(ctx: ExtensionContext, model: Model<Api>): Promise<BudgetModelAuth | null> {
+	const result = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	if (!result.ok) return null;
+	return { apiKey: result.apiKey, headers: result.headers };
 }
 
 // --- Strategies ---
@@ -167,9 +191,9 @@ async function findSameProvider(
 
 	for (const candidate of candidates) {
 		if (candidate.cost.input >= activeModel.cost.input * costRatio) break;
-		const apiKey = await getApiKey(ctx, candidate);
-		if (apiKey) {
-			return { model: candidate, apiKey };
+		const auth = await resolveAuth(ctx, candidate);
+		if (auth) {
+			return { model: candidate, auth };
 		}
 	}
 
@@ -210,9 +234,9 @@ async function findAnyProvider(
 
 	for (const model of allCandidates) {
 		if (model.cost.input >= activeModel.cost.input * costRatio) break;
-		const apiKey = await getApiKey(ctx, model);
-		if (apiKey) {
-			return { model, apiKey };
+		const auth = await resolveAuth(ctx, model);
+		if (auth) {
+			return { model, auth };
 		}
 	}
 
@@ -231,12 +255,12 @@ async function resolveModelOverride(ctx: ExtensionContext, override: string): Pr
 		throw new NoBudgetModelError(`model override "${override}" not found in registry`);
 	}
 
-	const apiKey = await getApiKey(ctx, model);
-	if (!apiKey) {
+	const auth = await resolveAuth(ctx, model);
+	if (!auth) {
 		throw new NoBudgetModelError(`no API key for model override "${override}"`);
 	}
 
-	return { model, apiKey };
+	return { model, auth };
 }
 
 // --- Shared internals ---
@@ -279,15 +303,21 @@ export function findCheapestInMajorVersions(models: Model<Api>[], majorVersions:
 	return eligible;
 }
 
-/** Build a ModelCandidate from a Model (checks API key availability). */
+/**
+ * Build a ModelCandidate from a Model.
+ *
+ * `hasApiKey` is kept for backwards compatibility but now reflects "has any usable auth":
+ * a model authenticated entirely via headers will report `hasApiKey: true`. We check this
+ * with `hasConfiguredAuth` (a fast, non-async probe) so building error-context candidates
+ * doesn't trigger OAuth refreshes or other expensive resolution work.
+ */
 async function toCandidate(ctx: ExtensionContext, model: Model<Api>, provider: string): Promise<ModelCandidate> {
-	const apiKey = await getApiKey(ctx, model);
 	return {
 		provider,
 		modelId: model.id,
 		costInput: model.cost.input,
 		costOutput: model.cost.output,
-		hasApiKey: !!apiKey,
+		hasApiKey: ctx.modelRegistry.hasConfiguredAuth(model),
 	};
 }
 

--- a/packages/budget-model/src/index.ts
+++ b/packages/budget-model/src/index.ts
@@ -121,6 +121,11 @@ export async function findBudgetModel(ctx: ExtensionContext, options?: BudgetMod
 	return findSameProvider(ctx, activeModel, opts.costRatio, opts.majorVersions);
 }
 
+async function getApiKey(ctx: ExtensionContext, model: Model<Api>): Promise<string | undefined> {
+	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	return auth.ok ? auth.apiKey : undefined;
+}
+
 // --- Strategies ---
 
 async function findSameProvider(
@@ -162,7 +167,7 @@ async function findSameProvider(
 
 	for (const candidate of candidates) {
 		if (candidate.cost.input >= activeModel.cost.input * costRatio) break;
-		const apiKey = await ctx.modelRegistry.getApiKey(candidate);
+		const apiKey = await getApiKey(ctx, candidate);
 		if (apiKey) {
 			return { model: candidate, apiKey };
 		}
@@ -205,7 +210,7 @@ async function findAnyProvider(
 
 	for (const model of allCandidates) {
 		if (model.cost.input >= activeModel.cost.input * costRatio) break;
-		const apiKey = await ctx.modelRegistry.getApiKey(model);
+		const apiKey = await getApiKey(ctx, model);
 		if (apiKey) {
 			return { model, apiKey };
 		}
@@ -226,7 +231,7 @@ async function resolveModelOverride(ctx: ExtensionContext, override: string): Pr
 		throw new NoBudgetModelError(`model override "${override}" not found in registry`);
 	}
 
-	const apiKey = await ctx.modelRegistry.getApiKey(model);
+	const apiKey = await getApiKey(ctx, model);
 	if (!apiKey) {
 		throw new NoBudgetModelError(`no API key for model override "${override}"`);
 	}
@@ -276,7 +281,7 @@ export function findCheapestInMajorVersions(models: Model<Api>[], majorVersions:
 
 /** Build a ModelCandidate from a Model (checks API key availability). */
 async function toCandidate(ctx: ExtensionContext, model: Model<Api>, provider: string): Promise<ModelCandidate> {
-	const apiKey = await ctx.modelRegistry.getApiKey(model);
+	const apiKey = await getApiKey(ctx, model);
 	return {
 		provider,
 		modelId: model.id,

--- a/packages/budget-model/src/index.ts
+++ b/packages/budget-model/src/index.ts
@@ -38,9 +38,27 @@ export const BudgetModelAuth = v.object({
 });
 export type BudgetModelAuth = v.InferOutput<typeof BudgetModelAuth>;
 
+/**
+ * Pin a specific model, bypassing auto-selection.
+ *
+ * - String form `"provider/model-id"`: registry resolves both the model metadata
+ *   and the auth credentials. Equivalent to v1.
+ * - Object form `{ model, auth }`: registry resolves the model metadata via
+ *   `find()`, but auth is taken straight from the option — the registry's auth
+ *   resolution is not invoked. Use this as an escape hatch when the registry's
+ *   auth pipeline misbehaves for your provider.
+ */
+export const ModelOverride = v.union([
+	v.pipe(v.string(), v.regex(/^[^/]+\/.+$/, 'must be "provider/model-id"')),
+	v.object({
+		model: v.pipe(v.string(), v.regex(/^[^/]+\/.+$/, 'must be "provider/model-id"')),
+		auth: BudgetModelAuth,
+	}),
+]);
+export type ModelOverride = v.InferOutput<typeof ModelOverride>;
+
 export const BudgetModelOptions = v.object({
-	/** Pin a specific model, bypassing auto-selection entirely. Format: "provider/model-id". */
-	modelOverride: v.optional(v.pipe(v.string(), v.regex(/^[^/]+\/.+$/, 'must be "provider/model-id"'))),
+	modelOverride: v.optional(ModelOverride),
 	strategy: v.optional(ModelStrategy, "same-provider"),
 	costRatio: v.optional(v.pipe(v.number(), v.minValue(0), v.maxValue(1)), 0.5),
 	/** How many major versions to search. 1 = latest only, 2 = latest + previous, 0 = all. */
@@ -245,19 +263,27 @@ async function findAnyProvider(
 
 // --- Model override ---
 
-async function resolveModelOverride(ctx: ExtensionContext, override: string): Promise<BudgetModel> {
-	const slashIndex = override.indexOf("/");
-	const provider = override.slice(0, slashIndex);
-	const modelId = override.slice(slashIndex + 1);
+async function resolveModelOverride(ctx: ExtensionContext, override: ModelOverride): Promise<BudgetModel> {
+	const modelId = typeof override === "string" ? override : override.model;
+	const slashIndex = modelId.indexOf("/");
+	const provider = modelId.slice(0, slashIndex);
+	const id = modelId.slice(slashIndex + 1);
 
-	const model = ctx.modelRegistry.find(provider, modelId);
+	const model = ctx.modelRegistry.find(provider, id);
 	if (!model) {
-		throw new NoBudgetModelError(`model override "${override}" not found in registry`);
+		throw new NoBudgetModelError(`model override "${modelId}" not found in registry`);
+	}
+
+	// Object form: skip the registry's auth pipeline entirely. The caller is
+	// telling us "use these credentials, I don't care what the registry would
+	// resolve." This is the escape hatch for when registry auth is broken.
+	if (typeof override !== "string") {
+		return { model, auth: override.auth };
 	}
 
 	const auth = await resolveAuth(ctx, model);
 	if (!auth) {
-		throw new NoBudgetModelError(`no API key for model override "${override}"`);
+		throw new NoBudgetModelError(`no API key for model override "${modelId}"`);
 	}
 
 	return { model, auth };

--- a/packages/budget-model/test/auth.test.ts
+++ b/packages/budget-model/test/auth.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Auth-resolution tests for findBudgetModel.
+ *
+ * These exercise budget-model's handling of `getApiKeyAndHeaders`, the upstream
+ * registry primitive whose contract is:
+ *
+ *   { ok: true, apiKey?: string, headers?: Record<string, string> }
+ *   | { ok: false, error: string }
+ *
+ * Both `apiKey` and `headers` are optional on success, so the package must
+ * forward whatever the registry returns and treat `ok: true` (not `apiKey`
+ * truthiness) as the gate for "model is usable". Header-only providers
+ * (e.g. AWS Bedrock with SDK auth) are the regression case this guards.
+ *
+ * The model list is loaded from the installed @mariozechner/pi-ai package
+ * (per the repo's "live data, not fixtures" rule). The registry itself is
+ * faked because we're testing the seam between budget-model and the registry,
+ * not the registry's resolution logic.
+ */
+
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { findBudgetModel } from "../src/index.js";
+import { loadModels, modelsForProvider } from "./load-models.js";
+
+type ResolvedRequestAuth =
+	| { ok: true; apiKey?: string; headers?: Record<string, string> }
+	| { ok: false; error: string };
+
+interface FakeRegistry {
+	getAll(): Model<Api>[];
+	getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth>;
+	hasConfiguredAuth(model: Model<Api>): boolean;
+	find(provider: string, modelId: string): Model<Api> | undefined;
+}
+
+function makeCtx(
+	models: Model<Api>[],
+	resolve: (model: Model<Api>) => ResolvedRequestAuth,
+	activeModel: Model<Api> | undefined,
+): ExtensionContext {
+	const registry: FakeRegistry = {
+		getAll: () => models,
+		getApiKeyAndHeaders: async (model) => resolve(model),
+		hasConfiguredAuth: (model) => {
+			const r = resolve(model);
+			return r.ok;
+		},
+		find: (provider, modelId) => models.find((m) => String(m.provider) === provider && m.id === modelId),
+	};
+	// Cast: we only exercise modelRegistry + model on this fake.
+	return {
+		modelRegistry: registry as unknown as ExtensionContext["modelRegistry"],
+		model: activeModel,
+	} as unknown as ExtensionContext;
+}
+
+/**
+ * Pick a provider that has at least three models with a cost spread, so the
+ * cost-ratio check can pass for a cheaper candidate. We deliberately don't
+ * hardcode a provider name: the live model list moves over time.
+ */
+async function pickProviderAndActiveModel(): Promise<{ models: Model<Api>[]; active: Model<Api> }> {
+	const all = await loadModels();
+	const providers = new Set(all.map((m) => String(m.provider)));
+	for (const p of providers) {
+		const ms = modelsForProvider(all, p);
+		if (ms.length < 2) continue;
+		const sorted = [...ms].sort((a, b) => b.cost.input - a.cost.input);
+		const expensive = sorted[0];
+		const cheapest = sorted[sorted.length - 1];
+		// Need a real spread so the default 0.5 cost ratio admits something.
+		if (cheapest.cost.input > 0 && cheapest.cost.input < expensive.cost.input * 0.5) {
+			return { models: all, active: expensive };
+		}
+	}
+	throw new Error("no provider in live model list has a usable cost spread for these tests");
+}
+
+describe("findBudgetModel auth resolution", () => {
+	it("forwards apiKey from the registry on BudgetModel.auth", async () => {
+		const { models, active } = await pickProviderAndActiveModel();
+		const ctx = makeCtx(models, () => ({ ok: true, apiKey: "sk-test" }), active);
+
+		const result = await findBudgetModel(ctx);
+
+		expect(result.auth.apiKey).toBe("sk-test");
+		expect(result.auth.headers).toBeUndefined();
+	});
+
+	it("forwards headers from the registry, even when apiKey is absent", async () => {
+		// Regression case: providers that authenticate via headers (Bedrock-style)
+		// had auth.ok === true with apiKey undefined. The pre-fix wrapper rejected
+		// them as "no key"; the fix must accept them.
+		const { models, active } = await pickProviderAndActiveModel();
+		const ctx = makeCtx(models, () => ({ ok: true, headers: { Authorization: "Bearer header-only" } }), active);
+
+		const result = await findBudgetModel(ctx);
+
+		expect(result.auth.apiKey).toBeUndefined();
+		expect(result.auth.headers).toEqual({ Authorization: "Bearer header-only" });
+	});
+
+	it("forwards both apiKey and headers when the registry resolves both", async () => {
+		const { models, active } = await pickProviderAndActiveModel();
+		const ctx = makeCtx(models, () => ({ ok: true, apiKey: "sk-test", headers: { "X-Trace": "abc" } }), active);
+
+		const result = await findBudgetModel(ctx);
+
+		expect(result.auth).toEqual({ apiKey: "sk-test", headers: { "X-Trace": "abc" } });
+	});
+
+	it("treats ok:false as 'no auth' and surfaces NoBudgetModelError", async () => {
+		const { models, active } = await pickProviderAndActiveModel();
+		const ctx = makeCtx(models, () => ({ ok: false, error: "401" }), active);
+
+		await expect(findBudgetModel(ctx)).rejects.toThrow(/no API key available/);
+	});
+
+	it("accepts ok:true with neither apiKey nor headers (SDK-resolved auth)", async () => {
+		// Some providers (e.g. AWS Bedrock with SDK credentials) report ok:true
+		// with both fields empty. The downstream provider in pi-ai handles auth
+		// itself; budget-model must not gate on apiKey/headers truthiness.
+		const { models, active } = await pickProviderAndActiveModel();
+		const ctx = makeCtx(models, () => ({ ok: true }), active);
+
+		const result = await findBudgetModel(ctx);
+
+		expect(result.auth.apiKey).toBeUndefined();
+		expect(result.auth.headers).toBeUndefined();
+		expect(result.model).toBeDefined();
+	});
+});

--- a/packages/budget-model/test/auth.test.ts
+++ b/packages/budget-model/test/auth.test.ts
@@ -170,6 +170,28 @@ describe("findBudgetModel modelOverride object form", () => {
 		).rejects.toThrow(/not found in registry/);
 	});
 
+	it("accepts an empty auth object (caller defers auth to ambient credentials)", async () => {
+		// `BudgetModelAuth` has both fields optional. A caller using SDK-resolved
+		// credentials (e.g. AWS Bedrock with profile-based auth) may legitimately
+		// supply `auth: {}` — the downstream provider in pi-ai handles auth itself.
+		// We assert that's not rejected.
+		const all = await loadModels();
+		const override = all[0];
+		const ctx = makeCtx(
+			all,
+			() => {
+				throw new Error("registry auth pipeline must not be invoked for object-form modelOverride");
+			},
+			undefined,
+		);
+
+		const result = await findBudgetModel(ctx, {
+			modelOverride: { model: `${String(override.provider)}/${override.id}`, auth: {} },
+		});
+
+		expect(result.auth).toEqual({});
+	});
+
 	it("string form still works (registry resolves both model and auth)", async () => {
 		const all = await loadModels();
 		const override = all[0];

--- a/packages/budget-model/test/auth.test.ts
+++ b/packages/budget-model/test/auth.test.ts
@@ -132,3 +132,53 @@ describe("findBudgetModel auth resolution", () => {
 		expect(result.model).toBeDefined();
 	});
 });
+
+describe("findBudgetModel modelOverride object form", () => {
+	it("uses the supplied auth without consulting the registry's auth pipeline", async () => {
+		// The point of the object form: it must work even when the registry's
+		// getApiKeyAndHeaders is broken. We assert that by making the fake throw
+		// if it's called — the object form must not invoke it.
+		const all = await loadModels();
+		const override = all[0];
+		const ctx = makeCtx(
+			all,
+			() => {
+				throw new Error("registry auth pipeline must not be invoked for object-form modelOverride");
+			},
+			undefined,
+		);
+
+		const result = await findBudgetModel(ctx, {
+			modelOverride: {
+				model: `${String(override.provider)}/${override.id}`,
+				auth: { apiKey: "user-supplied", headers: { "X-Trace": "abc" } },
+			},
+		});
+
+		expect(result.model.id).toBe(override.id);
+		expect(result.auth).toEqual({ apiKey: "user-supplied", headers: { "X-Trace": "abc" } });
+	});
+
+	it("still throws if the override model isn't in the registry", async () => {
+		const all = await loadModels();
+		const ctx = makeCtx(all, () => ({ ok: true }), undefined);
+
+		await expect(
+			findBudgetModel(ctx, {
+				modelOverride: { model: "bogus/does-not-exist", auth: { apiKey: "x" } },
+			}),
+		).rejects.toThrow(/not found in registry/);
+	});
+
+	it("string form still works (registry resolves both model and auth)", async () => {
+		const all = await loadModels();
+		const override = all[0];
+		const ctx = makeCtx(all, () => ({ ok: true, apiKey: "sk-from-registry" }), undefined);
+
+		const result = await findBudgetModel(ctx, {
+			modelOverride: `${String(override.provider)}/${override.id}`,
+		});
+
+		expect(result.auth.apiKey).toBe("sk-from-registry");
+	});
+});

--- a/packages/desktop-notify/package.json
+++ b/packages/desktop-notify/package.json
@@ -47,7 +47,7 @@
     }
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/enclave/package.json
+++ b/packages/enclave/package.json
@@ -45,7 +45,7 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/jujutsu/package.json
+++ b/packages/jujutsu/package.json
@@ -41,7 +41,7 @@
 		"@mariozechner/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@mariozechner/pi-coding-agent": "^0.57.0",
+		"@mariozechner/pi-coding-agent": "^0.63.0",
 		"@mariozechner/pi-tui": "^0.57.0",
 		"@types/node": "^25.3.5",
 		"tsup": "^8.5.1",

--- a/packages/no-soft-cursor/package.json
+++ b/packages/no-soft-cursor/package.json
@@ -39,8 +39,8 @@
 		"@mariozechner/pi-tui": "*"
 	},
 	"devDependencies": {
-		"@mariozechner/pi-coding-agent": "^0.57.0",
-		"@mariozechner/pi-tui": "^0.57.0",
+		"@mariozechner/pi-coding-agent": "^0.63.0",
+		"@mariozechner/pi-tui": "^0.63.0",
 		"@types/node": "^25.3.5",
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3"

--- a/packages/safeguard/package.json
+++ b/packages/safeguard/package.json
@@ -44,8 +44,8 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-ai": "^0.57.0",
-    "@mariozechner/pi-coding-agent": "^0.57.0",
+    "@mariozechner/pi-ai": "^0.63.0",
+    "@mariozechner/pi-coding-agent": "^0.63.0",
     "@types/node": "^25.3.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/safeguard/src/index.ts
+++ b/packages/safeguard/src/index.ts
@@ -247,7 +247,7 @@ async function evaluate(
 	try {
 		const verdict = await callJudge(
 			judge.model,
-			judge.apiKey,
+			judge.auth,
 			action,
 			ctx.cwd,
 			recentContext,

--- a/packages/safeguard/src/judge.ts
+++ b/packages/safeguard/src/judge.ts
@@ -1,5 +1,6 @@
 import { completeSimple } from "@mariozechner/pi-ai";
 import type { Api, Model } from "@mariozechner/pi-ai";
+import type { BudgetModelAuth } from "pi-budget-model";
 import type { Verdict } from "./types.js";
 
 export function parseVerdict(text: string): Verdict {
@@ -23,7 +24,7 @@ export interface BatchEntry {
 
 export async function callJudge(
 	model: Model<Api>,
-	apiKey: string,
+	auth: BudgetModelAuth,
 	action: string,
 	cwd: string,
 	recentContext: string,
@@ -58,7 +59,7 @@ export async function callJudge(
 				messages: [{ role: "user", content: parts.join("\n"), timestamp: Date.now() }],
 			},
 			{
-				apiKey,
+				...auth,
 				signal: controller.signal,
 				maxTokens: 250,
 				temperature: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,7 +1436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mariozechner/pi-coding-agent@npm:*, @mariozechner/pi-coding-agent@npm:^0.57.0":
+"@mariozechner/pi-coding-agent@npm:*":
   version: 0.57.0
   resolution: "@mariozechner/pi-coding-agent@npm:0.57.0"
   dependencies:
@@ -1520,7 +1520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mariozechner/pi-tui@npm:^0.63.2":
+"@mariozechner/pi-tui@npm:^0.63.0, @mariozechner/pi-tui@npm:^0.63.2":
   version: 0.63.2
   resolution: "@mariozechner/pi-tui@npm:0.63.2"
   dependencies:
@@ -4584,7 +4584,7 @@ __metadata:
   resolution: "pi-bash-bg@workspace:packages/bash-bg"
   dependencies:
     "@aliou/sh": "npm:^0.1.0"
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     tsup: "npm:^8.5.1"
     typescript: "npm:^5.9.3"
@@ -4598,7 +4598,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pi-bash-trim@workspace:packages/bash-trim"
   dependencies:
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     gpt-tokenizer: "npm:^3.4.0"
     tsup: "npm:^8.5.1"
@@ -4629,7 +4629,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pi-desktop-notify@workspace:packages/desktop-notify"
   dependencies:
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     tsup: "npm:^8.5.1"
     typescript: "npm:^5.9.3"
@@ -4646,7 +4646,7 @@ __metadata:
   resolution: "pi-enclave@workspace:packages/enclave"
   dependencies:
     "@earendil-works/gondolin": "npm:^0.6.0"
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     graphql: "npm:^16.13.1"
     smol-toml: "npm:^1.6.0"
@@ -4662,7 +4662,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pi-jujutsu@workspace:packages/jujutsu"
   dependencies:
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@mariozechner/pi-tui": "npm:^0.57.0"
     "@types/node": "npm:^25.3.5"
     tsup: "npm:^8.5.1"
@@ -4677,8 +4677,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pi-no-soft-cursor@workspace:packages/no-soft-cursor"
   dependencies:
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
-    "@mariozechner/pi-tui": "npm:^0.57.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
+    "@mariozechner/pi-tui": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     tsup: "npm:^8.5.1"
     typescript: "npm:^5.9.3"
@@ -4693,8 +4693,8 @@ __metadata:
   resolution: "pi-safeguard@workspace:packages/safeguard"
   dependencies:
     "@aliou/sh": "npm:^0.1.0"
-    "@mariozechner/pi-ai": "npm:^0.57.0"
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-ai": "npm:^0.63.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     pi-budget-model: "workspace:*"
     tsup: "npm:^8.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4620,8 +4620,8 @@ __metadata:
     typescript: "npm:^5.9.3"
     valibot: "npm:^1.2.0"
   peerDependencies:
-    "@mariozechner/pi-ai": "*"
-    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-ai": ">=0.63.0"
+    "@mariozechner/pi-coding-agent": ">=0.63.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1381,6 +1381,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mariozechner/pi-agent-core@npm:^0.63.2":
+  version: 0.63.2
+  resolution: "@mariozechner/pi-agent-core@npm:0.63.2"
+  dependencies:
+    "@mariozechner/pi-ai": "npm:^0.63.2"
+  checksum: 10c0/6a8644e6e54b69e83dd109630d09e4af7a1606fa5026fb207a7d2022934e36682550672c74ed5f48d2b28007d6dd8adb3cac9337e6c0c9059a15cfbb49093808
+  languageName: node
+  linkType: hard
+
 "@mariozechner/pi-ai@npm:*, @mariozechner/pi-ai@npm:^0.57.0":
   version: 0.57.0
   resolution: "@mariozechner/pi-ai@npm:0.57.0"
@@ -1401,6 +1410,29 @@ __metadata:
   bin:
     pi-ai: dist/cli.js
   checksum: 10c0/f09009364ef40508bcebf4f042f7860b05e27b01e4c3075614d1c7264670a69cc79ea54ba6f5d174045c91cbc224990fac9a7103b3d5ccf3fac9501fe57f283d
+  languageName: node
+  linkType: hard
+
+"@mariozechner/pi-ai@npm:^0.63.0, @mariozechner/pi-ai@npm:^0.63.2":
+  version: 0.63.2
+  resolution: "@mariozechner/pi-ai@npm:0.63.2"
+  dependencies:
+    "@anthropic-ai/sdk": "npm:^0.73.0"
+    "@aws-sdk/client-bedrock-runtime": "npm:^3.983.0"
+    "@google/genai": "npm:^1.40.0"
+    "@mistralai/mistralai": "npm:1.14.1"
+    "@sinclair/typebox": "npm:^0.34.41"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    chalk: "npm:^5.6.2"
+    openai: "npm:6.26.0"
+    partial-json: "npm:^0.1.7"
+    proxy-agent: "npm:^6.5.0"
+    undici: "npm:^7.19.1"
+    zod-to-json-schema: "npm:^3.24.6"
+  bin:
+    pi-ai: dist/cli.js
+  checksum: 10c0/b1c881858ca44fee1a1749056b21fe90d6902d56dd89c57d470773055c435dfa68af1df37ffe565ca0ffa6fb8cacf91e25c2303eb7d52c60d0fe24b4943edcf9
   languageName: node
   linkType: hard
 
@@ -1437,6 +1469,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mariozechner/pi-coding-agent@npm:^0.63.0":
+  version: 0.63.2
+  resolution: "@mariozechner/pi-coding-agent@npm:0.63.2"
+  dependencies:
+    "@mariozechner/clipboard": "npm:^0.3.2"
+    "@mariozechner/jiti": "npm:^2.6.2"
+    "@mariozechner/pi-agent-core": "npm:^0.63.2"
+    "@mariozechner/pi-ai": "npm:^0.63.2"
+    "@mariozechner/pi-tui": "npm:^0.63.2"
+    "@silvia-odwyer/photon-node": "npm:^0.3.4"
+    ajv: "npm:^8.17.1"
+    chalk: "npm:^5.5.0"
+    cli-highlight: "npm:^2.1.11"
+    diff: "npm:^8.0.2"
+    extract-zip: "npm:^2.0.1"
+    file-type: "npm:^21.1.1"
+    glob: "npm:^13.0.1"
+    hosted-git-info: "npm:^9.0.2"
+    ignore: "npm:^7.0.5"
+    marked: "npm:^15.0.12"
+    minimatch: "npm:^10.2.3"
+    proper-lockfile: "npm:^4.1.2"
+    strip-ansi: "npm:^7.1.0"
+    undici: "npm:^7.19.1"
+    yaml: "npm:^2.8.2"
+  dependenciesMeta:
+    "@mariozechner/clipboard":
+      optional: true
+  bin:
+    pi: dist/cli.js
+  checksum: 10c0/cd8ffa7e2389979420fc45222a3248213dc46430083d608512a9f833aac48a20be62cb9bbdad87d7f26f617b9bffef0aff70d53baf766600d5901b322e27530e
+  languageName: node
+  linkType: hard
+
 "@mariozechner/pi-tui@npm:^0.57.0":
   version: 0.57.0
   resolution: "@mariozechner/pi-tui@npm:0.57.0"
@@ -1451,6 +1517,23 @@ __metadata:
     koffi:
       optional: true
   checksum: 10c0/7a7a9912e1388ce5d75287fe1d6863346ba8ef864d5962ff4d49b7e05d38d91a17ebfaefe3bf2638be4f968425ce493e358f7fd29dea7ef28728b1664d38e269
+  languageName: node
+  linkType: hard
+
+"@mariozechner/pi-tui@npm:^0.63.2":
+  version: 0.63.2
+  resolution: "@mariozechner/pi-tui@npm:0.63.2"
+  dependencies:
+    "@types/mime-types": "npm:^2.1.4"
+    chalk: "npm:^5.5.0"
+    get-east-asian-width: "npm:^1.3.0"
+    koffi: "npm:^2.9.0"
+    marked: "npm:^15.0.12"
+    mime-types: "npm:^3.0.1"
+  dependenciesMeta:
+    koffi:
+      optional: true
+  checksum: 10c0/576a865593e85642793bde9924559a2e3a511952d0e5bac0e5ed417f5f6e9229bc9f03582b786d1ef475bcb721dab64bcab88e1fb92fc64bcf1cd4dee66b4358
   languageName: node
   linkType: hard
 
@@ -4530,8 +4613,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pi-budget-model@workspace:packages/budget-model"
   dependencies:
-    "@mariozechner/pi-ai": "npm:^0.57.0"
-    "@mariozechner/pi-coding-agent": "npm:^0.57.0"
+    "@mariozechner/pi-ai": "npm:^0.63.0"
+    "@mariozechner/pi-coding-agent": "npm:^0.63.0"
     "@types/node": "npm:^25.3.5"
     tsup: "npm:^8.5.1"
     typescript: "npm:^5.9.3"


### PR DESCRIPTION
Supersedes #41 (kirberich's commit is preserved on this branch with original authorship).

## Why

#41 correctly identified that `modelRegistry.getApiKey` was removed upstream and switched to `getApiKeyAndHeaders`, but the wrapper extracted only `auth.apiKey` and discarded `auth.headers`. This left two regressions:

1. **Header-authenticated providers** (out-of-band `Authorization`, AWS Bedrock with SDK-resolved credentials, etc.) returned `{ ok: true, apiKey: undefined, headers: {...} }`. The wrapper gated on `apiKey` truthiness and rejected them as "no key" — the same symptom #41 was supposed to fix, just for a different subset of providers.
2. **CI was failing** because `pi-budget-model` bumped `@mariozechner/pi-coding-agent` to `^0.63.0` while sibling packages still pinned `^0.57.0`, so two copies were resolved and `ExtensionContext` types diverged.

## What this does

Four commits on top of #41's original commit:

### 1. `build:` align pi-coding-agent + pi-ai devDeps to `^0.63.0` across packages
Fixes the dts build by ensuring a single resolved copy of pi-coding-agent across the workspace. Also bumps `no-soft-cursor`'s pi-tui to `^0.63.0` for the same reason. devDependency-only at the source-code level, but the published `dist/*.d.ts` may reference newer upstream types, so a patch changeset documents this for `pi-bash-bg`, `pi-bash-trim`, `pi-desktop-notify`, `pi-enclave`, `pi-jujutsu`, `pi-no-soft-cursor`.

### 2. `fix(budget-model):` preserve auth headers — **BREAKING**
- `BudgetModel` now exposes a nested `auth: BudgetModelAuth` field instead of a flat `apiKey: string`. New shape forwards both `apiKey` and `headers` to pi-ai's `completeSimple`/`stream` via the `{ ...auth, signal, ... }` spread idiom.
- `BudgetModelAuth` is exported as a valibot schema, reusable across the public surface.
- Auth gate switches from "is `apiKey` truthy" to "is `result.ok` true" — header-only and SDK-auth providers now select correctly.
- `toCandidate.hasApiKey` now uses `registry.hasConfiguredAuth` (a fast, non-async upstream probe) and reflects "has any usable auth"; the field name is kept for backwards compat.
- `peerDependencies` tightened to `>=0.63.0` so consumers can't install against a pi version that lacks `getApiKeyAndHeaders`.
- `pi-safeguard` updated to forward the new auth shape (`{ ...judge.auth, signal, ... }`) into `completeSimple`.
- Major bump for `pi-budget-model`, patch for `pi-safeguard`. Migration guide in the changeset.

### 3. `feat(budget-model):` modelOverride object form (escape hatch)
`modelOverride` now accepts `{ model: "provider/id", auth: BudgetModelAuth }` in addition to the bare string. The object form skips the registry's auth pipeline entirely; `find()` is still used to resolve model metadata. This is the workaround for future upstream auth breakages — if `getApiKeyAndHeaders` ever shifts shape again, users can supply credentials directly.

```ts
findBudgetModel(ctx, {
  modelOverride: {
    model: "openai/gpt-4o-mini",
    auth: { apiKey: process.env.OPENAI_API_KEY },
  },
});
```

Minor bump.

### 4. `docs(budget-model):` README + JSDoc
README usage examples updated from `{ model, apiKey }` to `{ model, auth }` with the spread idiom; new section documenting both forms of `modelOverride` including the auth-bypass use case. Restored JSDoc on `BudgetModel` and expanded `findBudgetModel`'s doc comment to describe override semantics.

## Tests

`packages/budget-model/test/auth.test.ts` (9 cases). Model list comes from the real installed `@mariozechner/pi-ai` per the repo's "live data, not fixtures" rule; only the registry is faked, since we're testing budget-model's handling of the registry contract:

| Case | Asserts |
|---|---|
| apiKey-only | forwarded to `auth.apiKey`, no headers |
| headers-only | forwarded to `auth.headers`, regression case for Bedrock-style auth |
| both | both forwarded |
| `ok: false` | `NoBudgetModelError` |
| `ok: true` with neither | accepted (SDK-resolved auth) |
| override object form | uses supplied auth without invoking `getApiKeyAndHeaders` (asserted by making the fake throw if called) |
| override object form, empty auth `{}` | accepted (caller defers to ambient credentials) |
| override missing model | still fails fast with "not found in registry" |
| override string form | still works (regression guard) |

All 482 tests pass; lint clean.

## Migration

For consumers of `pi-budget-model`:

```diff
 const judge = await findBudgetModel(ctx);
-await completeSimple(judge.model, ctx, { apiKey: judge.apiKey, signal });
+await completeSimple(judge.model, ctx, { ...judge.auth, signal });
```

If you need to read the apiKey directly, it's now `judge.auth.apiKey` (`string | undefined`).
