### PR TITLE
fix(pi-no-soft-cursor): keep soft cursor visible while autocomplete is open

### DIFF
--- a/.changeset/no-soft-cursor-keep-cursor-during-autocomplete.md
+++ b/.changeset/no-soft-cursor-keep-cursor-during-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"pi-no-soft-cursor": patch
+---
+
+Keep the soft cursor visible while the editor's autocomplete (e.g. the `@`-file picker) is open, so the cursor doesn't disappear when no hardware-cursor marker is emitted (#45).

--- a/packages/no-soft-cursor/src/index.ts
+++ b/packages/no-soft-cursor/src/index.ts
@@ -20,7 +20,8 @@ const INTERACTIVE_MODE_PATCHED = Symbol.for("pi-no-soft-cursor.interactive-mode-
 type Keybindings = ConstructorParameters<typeof CustomEditor>[2];
 type EditorFactory = (tui: TUI, theme: EditorTheme, keybindings: Keybindings) => EditorComponent;
 type HardwareCursorCapable = { tui?: { setShowHardwareCursor?(show: boolean): void } };
-type PatchedEditor = EditorComponent & HardwareCursorCapable & { [RENDER_PATCHED]?: boolean };
+type AutocompleteAware = { autocompleteState?: unknown };
+type PatchedEditor = EditorComponent & HardwareCursorCapable & AutocompleteAware & { [RENDER_PATCHED]?: boolean };
 type PatchableUI = {
 	[UI_PATCHED]?: boolean;
 	setEditorComponent(factory: EditorFactory | undefined): void;
@@ -30,7 +31,7 @@ function forceHardwareCursor(editor: unknown) {
 	(editor as HardwareCursorCapable | undefined)?.tui?.setShowHardwareCursor?.(true);
 }
 
-function patchEditorRender<T extends EditorComponent>(editor: T): T {
+export function patchEditorRender<T extends EditorComponent>(editor: T): T {
 	const patchedEditor = editor as PatchedEditor;
 	forceHardwareCursor(patchedEditor);
 	if (patchedEditor[RENDER_PATCHED]) return editor;
@@ -38,7 +39,13 @@ function patchEditorRender<T extends EditorComponent>(editor: T): T {
 	const originalRender = editor.render.bind(editor);
 	patchedEditor.render = ((width: number) => {
 		forceHardwareCursor(patchedEditor);
-		return originalRender(width).map(stripSoftCursor);
+		const lines = originalRender(width);
+		// When autocomplete (e.g. the @-file picker) is active, upstream pi
+		// suppresses the hardware-cursor marker but still draws the soft cursor.
+		// Stripping in that mode would leave no cursor visible at all (issue #45),
+		// so fall back to the soft cursor until autocomplete closes.
+		if (patchedEditor.autocompleteState) return lines;
+		return lines.map(stripSoftCursor);
 	}) as typeof editor.render;
 	patchedEditor[RENDER_PATCHED] = true;
 	return editor;

--- a/packages/no-soft-cursor/test/patch-editor-render.test.ts
+++ b/packages/no-soft-cursor/test/patch-editor-render.test.ts
@@ -1,0 +1,76 @@
+import type { EditorComponent } from "@mariozechner/pi-tui";
+import { describe, expect, it } from "vitest";
+import { patchEditorRender } from "../src/index.js";
+
+const REV = "\x1b[7m";
+const RST = "\x1b[0m";
+
+type AutocompleteState = { items: string[] } | null;
+
+interface FakeEditor extends EditorComponent {
+	autocompleteState: AutocompleteState;
+	tui: { setShowHardwareCursor(show: boolean): void };
+	hardwareCursorCalls: boolean[];
+}
+
+function makeFakeEditor(linesProvider: () => string[]): FakeEditor {
+	const editor = {
+		autocompleteState: null as AutocompleteState,
+		hardwareCursorCalls: [] as boolean[],
+		tui: {
+			setShowHardwareCursor(show: boolean) {
+				editor.hardwareCursorCalls.push(show);
+			},
+		},
+		render(_width: number) {
+			return linesProvider();
+		},
+	} as unknown as FakeEditor;
+	return editor;
+}
+
+describe("patchEditorRender", () => {
+	it("strips the soft cursor when autocomplete is inactive", () => {
+		const editor = makeFakeEditor(() => [`hello${REV}X${RST} `]);
+		const patched = patchEditorRender(editor);
+
+		expect(patched.render(80)).toEqual(["helloX "]);
+	});
+
+	it("preserves the soft cursor while autocomplete is active (issue #45)", () => {
+		// When the file picker (`@`) is open, pi suppresses the hardware-cursor
+		// marker, so the soft cursor is the only indicator. Stripping it leaves
+		// the user with no visible cursor at all.
+		const editor = makeFakeEditor(() => [`hello${REV}X${RST} `, "  src/index.ts"]);
+		editor.autocompleteState = { items: ["src/index.ts"] };
+		const patched = patchEditorRender(editor);
+
+		expect(patched.render(80)).toEqual([`hello${REV}X${RST} `, "  src/index.ts"]);
+	});
+
+	it("forces the hardware cursor on at construction and on each render", () => {
+		const editor = makeFakeEditor(() => ["text"]);
+		const patched = patchEditorRender(editor);
+
+		expect(editor.hardwareCursorCalls).toEqual([true]);
+		patched.render(80);
+		patched.render(80);
+		expect(editor.hardwareCursorCalls).toEqual([true, true, true]);
+	});
+
+	it("is idempotent: patching the same editor twice does not double-wrap render", () => {
+		let renderCount = 0;
+		const editor = makeFakeEditor(() => {
+			renderCount++;
+			return [`a${REV}b${RST}`];
+		});
+
+		patchEditorRender(editor);
+		patchEditorRender(editor);
+		editor.render(80);
+
+		expect(renderCount).toBe(1);
+		// Original render was called once and stripping was applied once.
+		expect(editor.render(80)).toEqual(["ab"]);
+	});
+});


### PR DESCRIPTION
Fixes #45.

## Root cause

When the editor's autocomplete is active (e.g. the `@`-file picker), upstream pi-tui's `Editor.render` does not emit `CURSOR_MARKER`:

```js
// pi-tui/dist/components/editor.js
const emitCursorMarker = this.focused && !this.autocompleteState;
```

Without that marker, `tui.positionHardwareCursor` hides the hardware cursor. The editor still draws the soft (reverse-video) cursor on the input line, which is the only cursor indicator the user has in that mode.

This extension was stripping that span unconditionally, so the user saw no cursor at all while the file picker was open.

## Fix

In `patchEditorRender`, skip the strip when `editor.autocompleteState` is truthy. The soft cursor falls back into view until autocomplete closes; once it does, hardware-cursor-only behavior resumes as before.

## Tests

Added `test/patch-editor-render.test.ts` covering:
- strips when autocomplete is inactive
- preserves the soft cursor while autocomplete is active (issue #45)
- forces hardware cursor on at construction and on every render
- idempotent when patching the same editor twice

## Notes

A more aggressive alternative would be to also override the marker suppression so the hardware cursor stays positioned during autocomplete. That would require monkey-patching `Editor.prototype.render` itself; the conservative fix here just falls back to upstream's soft-cursor behavior in that one mode.
