### PR TITLE
fix(jujutsu): stop watcher on stale ctx instead of crashing pi

### DIFF
--- a/.changeset/jujutsu-stale-ctx-watcher.md
+++ b/.changeset/jujutsu-stale-ctx-watcher.md
@@ -1,0 +1,5 @@
+---
+"pi-jujutsu": patch
+---
+
+Stop op-heads watcher when captured ctx is stale, fixing crash on `newSession`/`fork`/`switchSession`/`reload`.

--- a/packages/jujutsu/src/index.ts
+++ b/packages/jujutsu/src/index.ts
@@ -264,6 +264,17 @@ export default function (pi: ExtensionAPI) {
 				if (debounceTimer) clearTimeout(debounceTimer);
 				debounceTimer = setTimeout(async () => {
 					debounceTimer = null;
+					// The captured ctx may have been invalidated by newSession/fork/
+					// switchSession/reload between the fs event firing and this timer
+					// resolving. Probing ctx.hasUI throws synchronously when stale.
+					// Bail out and stop the watcher; a fresh extension instance will
+					// be created on the new runtime if applicable.
+					try {
+						void ctx.hasUI;
+					} catch {
+						stopWatcher();
+						return;
+					}
 					// Skip refresh while agent is running (it snapshots at turn_end)
 					if (agentActive) return;
 					await refreshLabel();


### PR DESCRIPTION
Closes #52
Closes #44

## Bug

The op-heads `fs.watch` callback captures the `ctx` from `session_start`/`session_switch` and reuses it inside a debounced `setTimeout`. After `newSession`, `fork`, `switchSession`, or `reload`, pi-coding-agent invalidates that `ctx`. The next filesystem event fires `patchFooter(ctx)`, reading `ctx.hasUI` throws synchronously, and because the throw happens inside a free-floating `setTimeout` (outside the runner's `emit()` try/catch), it kills the pi process.

Stack trace from the reports:

```
at ExtensionRunner.assertActive (.../runner.js:296:19)
at get hasUI (.../runner.js:385:24)
at patchFooter (.../pi-jujutsu/dist/index.js:161:14)
at Timeout._onTimeout (.../pi-jujutsu/dist/index.js:278:11)
```

## Fix

Probe `ctx.hasUI` at the top of the timer body; if it throws, call `stopWatcher()` and bail. A fresh extension instance is created on the new runtime if applicable.

The resize re-fetch path in `showWidget` was audited and left alone: `getDiffStat` is `async` so any synchronous `pi.exec` stale-throw becomes a promise rejection, swallowed by the existing `.catch`. The synchronous body of `render(width)` touches no `ctx`/`pi`.

## Why no test

The fix is a one-line liveness guard around code that's otherwise hard to exercise (real `fs.watch` + debounced `setTimeout` + closure state). A test would mostly assert the `try`/`catch` is present, which is implementation-detail testing per AGENTS.md.

## Verification

- `yarn workspace pi-jujutsu build` ✓
- `yarn test` — jujutsu tests pass; the unrelated `packages/safeguard/test/config.test.ts` failure is a pre-existing vite/valibot resolve issue.
- `yarn lint` ✓
- Changeset: `pi-jujutsu` patch.